### PR TITLE
fix: CFBundleShortVersionString in build.sh, splash autoresizingMask, README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Settings persist across launches via macOS UserDefaults.
 
 ## SSH Security
 
-- SSH connections use `StrictHostKeyChecking=accept-new` — new hosts are automatically added to `~/.ssh/known_hosts`, but changed host keys are rejected (protects against MITM attacks on reconnection)
+- SSH connections use `StrictHostKeyChecking=accept-new` — on the **first** connection to a new host, the host key is automatically added to `~/.ssh/known_hosts`. On all subsequent connections, a changed host key is rejected (protects against MITM attacks after the first connection)
 - `ExitOnForwardFailure=yes` — the tunnel fails immediately if port forwarding can't be established (no silent failures)
 - SSH key authentication is required — configure your SSH keys before using tunnel mode
 
@@ -99,6 +99,29 @@ Sources/HermesAgent/
 | `Package.swift` | Swift Package Manager manifest (macOS 12+, Swift 5.9+) |
 | `build.sh` | Build script — compiles, bundles .app, converts icon, installs |
 | `Hermes Icon.png` | Source icon (converted to .icns at build time) |
+
+## Troubleshooting
+
+**"Connection refused" or blank page in Direct mode**
+Hermes Web UI is not running on the configured URL. Start it first:
+```bash
+cd ~/hermes-webui-public && bash start.sh
+```
+Then use **Preferences → Reconnect** (or ⌘, → Save & Reconnect) to reload.
+
+**Gatekeeper blocks the app on first launch**
+This is expected — the app is not code-signed. Right-click → Open → Open, or run:
+```bash
+xattr -dr com.apple.quarantine "/Applications/Hermes Agent.app"
+```
+
+**SSH tunnel shows "disconnected" immediately**
+- Verify SSH key auth works in Terminal: `ssh user@your-server`
+- Check that hermes-webui is running on the remote port you configured
+- The remote port must match where hermes-webui listens (default: 8787)
+
+**App icon looks blurry**
+Run `killall Dock` after building from source to refresh the icon cache.
 
 ## Credits
 

--- a/Sources/HermesAgent/SplashWindowController.swift
+++ b/Sources/HermesAgent/SplashWindowController.swift
@@ -16,6 +16,7 @@ class SplashWindowController: NSWindowController {
         super.init(window: window)
 
         let container = NSView(frame: window.contentView!.bounds)
+        container.autoresizingMask = [.width, .height]
         container.wantsLayer = true
         container.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
         container.layer?.cornerRadius = 16

--- a/build.sh
+++ b/build.sh
@@ -43,6 +43,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <string>ai.get-hermes.HermesAgent</string>
     <key>CFBundleVersion</key>
     <string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
     <key>CFBundleExecutable</key>
     <string>$APP_NAME</string>
     <key>CFBundlePackageType</key>


### PR DESCRIPTION
## Fixes after security + code review

Full review covered: all Swift source files, GitHub Actions workflow, build.sh, README, release v1.0.0, entitlements, Info.plist generation.

**Security verdict: clean.** No exploits, no data loss risks, no injection surfaces. Details below.

---

### What this PR fixes

**`build.sh` — missing `CFBundleShortVersionString`**
The Info.plist generated by `build.sh` was missing this key. macOS uses it for the version string shown in Finder's Get Info panel and the About dialog. The CI workflow already had it; local builds did not. Added alongside `CFBundleVersion`.

**`SplashWindowController.swift` — container missing `autoresizingMask`**
The container `NSView` was initialized with the window's bounds but had no autoresizing mask. If the window were resized before the splash dismissed, the container would stay at its original size. Added `[.width, .height]`.

**`README.md` — two improvements**
- Clarified `StrictHostKeyChecking=accept-new`: the previous wording implied all new hosts are always auto-accepted. Corrected to say it only applies on the *first* connection; subsequent connections with changed host keys are still rejected.
- Added a **Troubleshooting** section covering the four most likely user stumbling points: blank page in Direct mode (hermes-webui not running), Gatekeeper quarantine, SSH disconnects, and blurry icon after local build.

---

### Security review summary

| Surface | Verdict | Notes |
|---|---|---|
| Image paste JS injection | ✅ Safe | base64 string is `[A-Za-z0-9+/=]` only — cannot break JS string literal |
| Text paste JS injection | ✅ Safe | `JSONEncoder` escapes clipboard text before injection |
| SSH argument injection | ✅ Safe | `Process.arguments` array is exec-style, never passed through `/bin/sh` |
| Target URL validation | ✅ Safe | Scheme restricted to `http`/`https`; `javascript:`, `file:` rejected |
| UserDefaults storage | ✅ Safe | Only stores username/hostname/ports/URL — no passwords or keys |
| Gatekeeper handling | ✅ Safe | README correctly documents quarantine removal |
| `StrictHostKeyChecking=accept-new` | ✅ Intentional | Auto-accepts first connection only; MITM protection on reconnect |
| Private WKWebKit prefs (KVC) | ℹ️ Note | Needed for clipboard to work; no public API equivalent today |
