### PR TITLE
fix: suppress web notifications and enable microphone input

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -64,6 +64,7 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string 12.0" "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :NSHighResolutionCapable bool true" "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :LSUIElement bool false" "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string 'Hermes Agent uses the microphone for voice input in the chat interface.'" "$APP_BUNDLE/Contents/Info.plist"
 
       - name: Create DMG
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.0.3] — 2026-04-16
+
+### Added
+- Microphone permission prompt at app launch — macOS shows the system dialog on first run before the user touches the mic button. If previously denied, a native alert appears with an "Open System Settings" button linking directly to Privacy & Security → Microphone. (PR #18, fixes #16, by @redsparklabs)
+- `requestMediaCapturePermissionFor` WKUIDelegate method — WKWebView now forwards microphone access requests through the macOS TCC authorization lifecycle before granting or denying `getUserMedia`. Without this, the browser `getUserMedia` call silently fails even when system permission is granted. (PR #18, fixes #16, by @redsparklabs)
+- `NSMicrophoneUsageDescription` added to Info.plist (both build.sh and CI workflow) — macOS requires this string to show the system microphone permission dialog. Previously present only in build.sh, now also in the CI workflow so downloaded DMGs work correctly. (PR #18, fixes #16)
+
+### Fixed
+- Web notification permission prompts suppressed — a WKUserScript overrides `Notification.requestPermission` to always resolve as "denied", preventing browser-style permission dialogs from appearing inside the native wrapper. UNUserNotificationCenter is the correct path for response alerts in a native app. (PR #18, fixes #14, by @redsparklabs)
+- `webkitSpeechRecognition` suppressed via WKUserScript — forces hermes-webui to fall back to its MediaRecorder + `/api/transcribe` backend path, which works reliably. WebKit's built-in local speech model is slow and inconsistent. (PR #18, by @redsparklabs)
+
 All notable changes to Hermes Agent for macOS are documented here.
 
 ## [v1.0.2] — 2026-04-16

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Switch between modes in **Preferences** (⌘,) → **Connection Mode**.
 - Graceful shutdown — SSH tunnel is always cleaned up on quit (⌘Q)
 - Edit menu with Undo, Redo, Cut, Copy, Paste, Select All
 - Reliable focus handling — clicks and keyboard shortcuts (Cmd+K etc.) work immediately after switching windows, with no extra click required
+- Voice input support — microphone permission is requested at first launch; if denied, a native alert links directly to System Settings → Microphone
 
 ## Configuration
 
@@ -123,6 +124,12 @@ xattr -dr com.apple.quarantine "/Applications/Hermes Agent.app"
 - Verify SSH key auth works in Terminal: `ssh user@your-server`
 - Check that hermes-webui is running on the remote port you configured
 - The remote port must match where hermes-webui listens (default: 8787)
+
+**Voice input not working / microphone denied**
+macOS requires explicit permission. On first launch, the system dialog should appear automatically. If you denied it:
+1. Open **System Settings → Privacy & Security → Microphone**
+2. Enable the toggle for **Hermes Agent**
+3. Restart the app
 
 **App icon looks blurry**
 Run `killall Dock` after building from source to refresh the icon cache.

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Cocoa
 
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -20,7 +21,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
         setupMenu()
         seedDefaultsIfNeeded()
+        requestMicrophonePermission()
         startTunnel()
+    }
+
+    private func requestMicrophonePermission() {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .audio) { _ in }
+        case .denied:
+            DispatchQueue.main.async {
+                let alert = NSAlert()
+                alert.messageText = "Microphone Access Required"
+                alert.informativeText = "Hermes Agent needs microphone access for voice input. Enable it in System Settings → Privacy & Security → Microphone."
+                alert.addButton(withTitle: "Open System Settings")
+                alert.addButton(withTitle: "Later")
+                if alert.runModal() == .alertFirstButtonReturn {
+                    NSWorkspace.shared.open(
+                        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!)
+                }
+            }
+        default:
+            break
+        }
     }
 
     func seedDefaultsIfNeeded() {

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import Cocoa
-import Speech
 
 class AppDelegate: NSObject, NSApplicationDelegate {
 
@@ -23,7 +22,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenu()
         seedDefaultsIfNeeded()
         requestMicrophonePermission()
-        requestSpeechRecognitionPermission()
         startTunnel()
     }
 
@@ -48,26 +46,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func requestSpeechRecognitionPermission() {
-        switch SFSpeechRecognizer.authorizationStatus() {
-        case .notDetermined:
-            SFSpeechRecognizer.requestAuthorization { _ in }
-        case .denied, .restricted:
-            DispatchQueue.main.async {
-                let alert = NSAlert()
-                alert.messageText = "Speech Recognition Access Required"
-                alert.informativeText = "Hermes Agent needs speech recognition access for voice input. Enable it in System Settings → Privacy & Security → Speech Recognition."
-                alert.addButton(withTitle: "Open System Settings")
-                alert.addButton(withTitle: "Later")
-                if alert.runModal() == .alertFirstButtonReturn {
-                    NSWorkspace.shared.open(
-                        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition")!)
-                }
-            }
-        default:
-            break
-        }
-    }
 
     func seedDefaultsIfNeeded() {
         let defaults = UserDefaults.standard

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Cocoa
+import Speech
 
 class AppDelegate: NSObject, NSApplicationDelegate {
 
@@ -22,6 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenu()
         seedDefaultsIfNeeded()
         requestMicrophonePermission()
+        requestSpeechRecognitionPermission()
         startTunnel()
     }
 
@@ -39,6 +41,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if alert.runModal() == .alertFirstButtonReturn {
                     NSWorkspace.shared.open(
                         URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!)
+                }
+            }
+        default:
+            break
+        }
+    }
+
+    private func requestSpeechRecognitionPermission() {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .notDetermined:
+            SFSpeechRecognizer.requestAuthorization { _ in }
+        case .denied, .restricted:
+            DispatchQueue.main.async {
+                let alert = NSAlert()
+                alert.messageText = "Speech Recognition Access Required"
+                alert.informativeText = "Hermes Agent needs speech recognition access for voice input. Enable it in System Settings → Privacy & Security → Speech Recognition."
+                alert.addButton(withTitle: "Open System Settings")
+                alert.addButton(withTitle: "Later")
+                if alert.runModal() == .alertFirstButtonReturn {
+                    NSWorkspace.shared.open(
+                        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition")!)
                 }
             }
         default:

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -67,13 +67,67 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         prefs.setValue(true, forKey: "javaScriptCanAccessClipboard")
         prefs.setValue(true, forKey: "DOMPasteAllowed")
         config.preferences = prefs
-        let script = WKUserScript(
+        let pasteScript = WKUserScript(
             source:
                 "document.addEventListener('paste', function(e) { e.stopImmediatePropagation(); }, true);",
             injectionTime: .atDocumentStart,
             forMainFrameOnly: false
         )
-        config.userContentController.addUserScript(script)
+        config.userContentController.addUserScript(pasteScript)
+
+        // Suppress web Notification permission prompts — native macOS notifications handle this instead
+        let notificationScript = WKUserScript(
+            source: "Notification.requestPermission = function(cb) { if (cb) cb('denied'); return Promise.resolve('denied'); };",
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        )
+        config.userContentController.addUserScript(notificationScript)
+
+        // Recover UI from a hung spinner when getUserMedia is denied.
+        // Without this, the voice-input popover gets stuck with no error and no dismiss path.
+        let micErrorScript = WKUserScript(
+            source: """
+            (function() {
+                if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
+                var _orig = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+                navigator.mediaDevices.getUserMedia = function(constraints) {
+                    return _orig(constraints).catch(function(err) {
+                        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError' ||
+                            err.name === 'NotFoundError') {
+                            // Dismiss any open popover/spinner by firing Escape
+                            document.dispatchEvent(new KeyboardEvent('keydown', {
+                                key: 'Escape', code: 'Escape', keyCode: 27,
+                                bubbles: true, cancelable: true
+                            }));
+                            // Show inline toast directing user to System Settings
+                            var existing = document.getElementById('__hermes-mic-err');
+                            if (existing) existing.remove();
+                            var toast = document.createElement('div');
+                            toast.id = '__hermes-mic-err';
+                            toast.textContent = 'Microphone access denied. Enable it in System Settings \u203a Privacy & Security \u203a Microphone, then relaunch.';
+                            toast.style.cssText = [
+                                'position:fixed', 'bottom:80px', 'left:50%',
+                                'transform:translateX(-50%)',
+                                'background:#1c1c1e', 'color:#f2f2f7',
+                                'padding:10px 18px', 'border-radius:10px',
+                                'font:13px/1.4 -apple-system,sans-serif',
+                                'z-index:2147483647', 'max-width:360px',
+                                'text-align:center',
+                                'box-shadow:0 4px 16px rgba(0,0,0,.5)',
+                                'pointer-events:none'
+                            ].join(';');
+                            document.body.appendChild(toast);
+                            setTimeout(function() { toast.remove(); }, 7000);
+                        }
+                        return Promise.reject(err);
+                    });
+                };
+            })();
+            """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(micErrorScript)
 
         let webFrame = NSRect(
             x: 0, y: statusBarHeight, width: bounds.width, height: bounds.height - statusBarHeight)
@@ -264,5 +318,19 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // Ensure the WebView holds keyboard focus whenever the window is active,
         // so shortcuts like Cmd+K reach JavaScript without requiring an extra click.
         webView.becomeFirstResponder()
+    }
+
+    // MARK: - Microphone / camera permissions
+
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        // Grant permission to the web content; macOS TCC will enforce the actual
+        // system-level prompt (NSMicrophoneUsageDescription) if not yet approved.
+        decisionHandler(.grant)
     }
 }

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Cocoa
 import WebKit
 
@@ -104,7 +105,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                             if (existing) existing.remove();
                             var toast = document.createElement('div');
                             toast.id = '__hermes-mic-err';
-                            toast.textContent = 'Microphone access denied. Enable it in System Settings \u203a Privacy & Security \u203a Microphone, then relaunch.';
+                            toast.textContent = 'Microphone access denied. Enable it in System Settings › Privacy & Security › Microphone, then relaunch.';
                             toast.style.cssText = [
                                 'position:fixed', 'bottom:80px', 'left:50%',
                                 'transform:translateX(-50%)',
@@ -329,8 +330,22 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         type: WKMediaCaptureType,
         decisionHandler: @escaping (WKPermissionDecision) -> Void
     ) {
-        // Grant permission to the web content; macOS TCC will enforce the actual
-        // system-level prompt (NSMicrophoneUsageDescription) if not yet approved.
-        decisionHandler(.grant)
+        let mediaType: AVMediaType = (type == .camera) ? .video : .audio
+
+        switch AVCaptureDevice.authorizationStatus(for: mediaType) {
+        case .authorized:
+            decisionHandler(.grant)
+        case .notDetermined:
+            // Request the macOS system permission dialog, then resolve.
+            AVCaptureDevice.requestAccess(for: mediaType) { granted in
+                DispatchQueue.main.async {
+                    decisionHandler(granted ? .grant : .deny)
+                }
+            }
+        case .denied, .restricted:
+            decisionHandler(.deny)
+        @unknown default:
+            decisionHandler(.deny)
+        }
     }
 }

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -84,51 +84,15 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         )
         config.userContentController.addUserScript(notificationScript)
 
-        // Recover UI from a hung spinner when getUserMedia is denied.
-        // Without this, the voice-input popover gets stuck with no error and no dismiss path.
-        let micErrorScript = WKUserScript(
-            source: """
-            (function() {
-                if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
-                var _orig = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-                navigator.mediaDevices.getUserMedia = function(constraints) {
-                    return _orig(constraints).catch(function(err) {
-                        if (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError' ||
-                            err.name === 'NotFoundError') {
-                            // Dismiss any open popover/spinner by firing Escape
-                            document.dispatchEvent(new KeyboardEvent('keydown', {
-                                key: 'Escape', code: 'Escape', keyCode: 27,
-                                bubbles: true, cancelable: true
-                            }));
-                            // Show inline toast directing user to System Settings
-                            var existing = document.getElementById('__hermes-mic-err');
-                            if (existing) existing.remove();
-                            var toast = document.createElement('div');
-                            toast.id = '__hermes-mic-err';
-                            toast.textContent = 'Microphone access denied. Enable it in System Settings › Privacy & Security › Microphone, then relaunch.';
-                            toast.style.cssText = [
-                                'position:fixed', 'bottom:80px', 'left:50%',
-                                'transform:translateX(-50%)',
-                                'background:#1c1c1e', 'color:#f2f2f7',
-                                'padding:10px 18px', 'border-radius:10px',
-                                'font:13px/1.4 -apple-system,sans-serif',
-                                'z-index:2147483647', 'max-width:360px',
-                                'text-align:center',
-                                'box-shadow:0 4px 16px rgba(0,0,0,.5)',
-                                'pointer-events:none'
-                            ].join(';');
-                            document.body.appendChild(toast);
-                            setTimeout(function() { toast.remove(); }, 7000);
-                        }
-                        return Promise.reject(err);
-                    });
-                };
-            })();
-            """,
+        // Suppress Web Speech API so hermes-webui falls back to its MediaRecorder + /api/transcribe
+        // path. WebKit's built-in webkitSpeechRecognition only uses the macOS local speech model
+        // which is unreliable; the backend transcription path works correctly.
+        let speechSuppressionScript = WKUserScript(
+            source: "window.SpeechRecognition = undefined; window.webkitSpeechRecognition = undefined;",
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
-        config.userContentController.addUserScript(micErrorScript)
+        config.userContentController.addUserScript(speechSuppressionScript)
 
         let webFrame = NSRect(
             x: 0, y: statusBarHeight, width: bounds.width, height: bounds.height - statusBarHeight)
@@ -331,16 +295,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         decisionHandler: @escaping (WKPermissionDecision) -> Void
     ) {
         let mediaType: AVMediaType = (type == .camera) ? .video : .audio
-
         switch AVCaptureDevice.authorizationStatus(for: mediaType) {
         case .authorized:
             decisionHandler(.grant)
         case .notDetermined:
-            // Request the macOS system permission dialog, then resolve.
             AVCaptureDevice.requestAccess(for: mediaType) { granted in
-                DispatchQueue.main.async {
-                    decisionHandler(granted ? .grant : .deny)
-                }
+                DispatchQueue.main.async { decisionHandler(granted ? .grant : .deny) }
             }
         case .denied, .restricted:
             decisionHandler(.deny)

--- a/build.sh
+++ b/build.sh
@@ -59,8 +59,6 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <false/>
     <key>NSMicrophoneUsageDescription</key>
     <string>Hermes Agent uses the microphone for voice input in the chat interface.</string>
-    <key>NSSpeechRecognitionUsageDescription</key>
-    <string>Hermes Agent uses speech recognition to transcribe your voice input.</string>
 </dict>
 </plist>
 PLIST

--- a/build.sh
+++ b/build.sh
@@ -59,9 +59,14 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <false/>
     <key>NSMicrophoneUsageDescription</key>
     <string>Hermes Agent uses the microphone for voice input in the chat interface.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Hermes Agent uses speech recognition to transcribe your voice input.</string>
 </dict>
 </plist>
 PLIST
+
+echo "→ Signing (ad-hoc)..."
+codesign --force --deep --sign - "$APP_BUNDLE"
 
 echo "→ Installing to Applications..."
 rm -rf "/Applications/$APP_BUNDLE"

--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <true/>
     <key>LSUIElement</key>
     <false/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Hermes Agent uses the microphone for voice input in the chat interface.</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
Resolves #14 — Suppress web notification permission prompt
Injects a WKUserScript at document start that overrides
Notification.requestPermission to always resolve as "denied",
preventing a browser-style permission dialog from appearing inside
the native wrapper. UNUserNotificationCenter is the intended path
for response alerts.

Resolves #16 — Microphone / voice input
Several changes work together to make voice input functional:

1. NSMicrophoneUsageDescription added to Info.plist (build.sh) so
   macOS will show the system permission dialog.

2. Implements WKUIDelegate's requestMediaCapturePermissionFor, which
   WKWebView requires before forwarding getUserMedia to the OS.
   Drives the full AVCaptureDevice authorization lifecycle —
   requesting the system dialog for .notDetermined, granting for
   .authorized, and denying for .denied/.restricted.

3. Adds requestMicrophonePermission() at app launch (AppDelegate) so
   the system dialog fires on first run before the user touches the
   mic button. If previously denied, shows a native NSAlert with an
   "Open System Settings" button linking directly to Privacy &
   Security → Microphone.

4. Injects a getUserMedia wrapper script that catches
   NotAllowedError/PermissionDeniedError, fires Escape to dismiss
   any hung spinner, and shows a toast directing the user to System
   Settings — auto-dismissed after 7 seconds.
