### PR TITLE
fix: restore WebView focus so buttons and Cmd+K respond reliably

### DIFF
--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -13,9 +13,15 @@ class BrowserWindow: NSWindow {
     }
 }
 
-class BrowserWindowController: NSWindowController, WKUIDelegate, WKNavigationDelegate {
+// Lets the first click on the WebView both focus it and register as a content
+// click simultaneously, fixing buttons that appear unresponsive after focus moves away.
+private class HermesWebView: WKWebView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
 
-    private var webView: WKWebView!
+class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegate, WKNavigationDelegate {
+
+    private var webView: HermesWebView!
     private var statusBar: NSView!
     private var separator: NSView!
     private var statusDot: NSView!
@@ -44,6 +50,7 @@ class BrowserWindowController: NSWindowController, WKUIDelegate, WKNavigationDel
         window.onPaste = { [weak self] in
             self?.handlePaste()
         }
+        window.delegate = self
 
         buildUI()
     }
@@ -70,7 +77,7 @@ class BrowserWindowController: NSWindowController, WKUIDelegate, WKNavigationDel
 
         let webFrame = NSRect(
             x: 0, y: statusBarHeight, width: bounds.width, height: bounds.height - statusBarHeight)
-        webView = WKWebView(frame: webFrame, configuration: config)
+        webView = HermesWebView(frame: webFrame, configuration: config)
         webView.autoresizingMask = [.width, .height]
         webView.uiDelegate = self
         webView.navigationDelegate = self
@@ -249,5 +256,13 @@ class BrowserWindowController: NSWindowController, WKUIDelegate, WKNavigationDel
         panel.beginSheetModal(for: self.window!) { response in
             completionHandler(response == .OK ? panel.urls : nil)
         }
+    }
+
+    // MARK: - Window focus
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        // Ensure the WebView holds keyboard focus whenever the window is active,
+        // so shortcuts like Cmd+K reach JavaScript without requiring an extra click.
+        webView.becomeFirstResponder()
     }
 }


### PR DESCRIPTION
Resolves #13

Summary
Clicks on buttons like "New conversation" had no effect after focus moved away from the WebView, and keyboard shortcuts like Cmd+K required an extra click to work.

Changes
Two changes work together:

HermesWebView subclass overrides acceptsFirstMouse to return true, so the click that refocuses the window also registers as a content click in JavaScript. Previously that first click was consumed entirely by focus restoration.

windowDidBecomeKey (NSWindowDelegate) calls webView.becomeFirstResponder() whenever the window becomes active, so keyboard shortcuts reach JavaScript immediately without requiring a manual click to restore focus first.