### PR TITLE
feat: Sparkle 2 auto-update, Developer ID signing + notarization (#17, #7)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve Swift packages
+        run: swift package resolve
+
       - name: Build universal binary (arm64 + x86_64)
         run: |
           swift build -c release --arch arm64
@@ -28,13 +31,25 @@ jobs:
         run: |
           APP_NAME="HermesAgent"
           DISPLAY_NAME="Hermes Agent"
-          BUILD_DIR=".build/universal"
           APP_BUNDLE="$DISPLAY_NAME.app"
+          VERSION="${GITHUB_REF_NAME#v}"
 
           mkdir -p "$APP_BUNDLE/Contents/MacOS"
           mkdir -p "$APP_BUNDLE/Contents/Resources"
-          cp "$BUILD_DIR/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/"
+          mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+
+          cp ".build/universal/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/"
           chmod +x "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+
+          # Embed Sparkle.framework (macOS slice from the xcframework)
+          SPARKLE_XCFRAMEWORK=$(find .build/artifacts -name "Sparkle.xcframework" | head -1)
+          SPARKLE_FW="$SPARKLE_XCFRAMEWORK/macos-arm64_x86_64/Sparkle.framework"
+          cp -R "$SPARKLE_FW" "$APP_BUNDLE/Contents/Frameworks/"
+
+          # Fix rpath so the binary finds the embedded framework
+          install_name_tool \
+            -add_rpath "@executable_path/../Frameworks" \
+            "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
           # Convert icon
           ICONSET="AppIcon.iconset"
@@ -52,19 +67,65 @@ jobs:
           iconutil -c icns "$ICONSET" -o "$APP_BUNDLE/Contents/Resources/AppIcon.icns"
           rm -rf "$ICONSET"
 
-          # Write Info.plist — use /usr/libexec/PlistBuddy for clean output
-          VERSION="${GITHUB_REF_NAME#v}"
-          /usr/libexec/PlistBuddy -c "Add :CFBundleName string 'Hermes Agent'" "$APP_BUNDLE/Contents/Info.plist"
+          # Write Info.plist
+          /usr/libexec/PlistBuddy -c "Add :CFBundleName string 'Hermes Agent'"              "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string ai.get-hermes.HermesAgent" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $VERSION" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $VERSION" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string HermesAgent" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string AppIcon" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string 12.0" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :NSHighResolutionCapable bool true" "$APP_BUNDLE/Contents/Info.plist"
-          /usr/libexec/PlistBuddy -c "Add :LSUIElement bool false" "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $VERSION"                 "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $VERSION"      "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleExecutable string HermesAgent"           "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :CFBundlePackageType string APPL"                 "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string AppIcon"                 "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string 12.0"              "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :NSHighResolutionCapable bool true"               "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :LSUIElement bool false"                          "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string 'Hermes Agent uses the microphone for voice input in the chat interface.'" "$APP_BUNDLE/Contents/Info.plist"
+          # Sparkle keys
+          /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string 'daAlTqdBbYPSCDjS9IfTCJOFDo1jqtjMRZluhtAbKMY='" "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :SUFeedURL string 'https://get-hermes.ai/appcast.xml'" "$APP_BUNDLE/Contents/Info.plist"
+
+      - name: Import Developer ID certificate
+        env:
+          CERT_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_CERT_P12 }}
+          CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+
+          echo "$CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "build-keychain-password" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "build-keychain-password" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$CERT_PASSWORD" -T /usr/bin/codesign
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+          security set-key-partition-list -S apple-tool:,apple: -s -k "build-keychain-password" "$KEYCHAIN_PATH"
+
+          rm "$CERT_PATH"
+
+      - name: Sign app bundle (Developer ID + hardened runtime)
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DISPLAY_NAME="Hermes Agent"
+          APP_BUNDLE="$DISPLAY_NAME.app"
+          IDENTITY="Developer ID Application"
+
+          # Sign nested frameworks and XPC services first
+          find "$APP_BUNDLE/Contents/Frameworks" -name "*.framework" -o -name "*.xpc" | while read f; do
+            codesign --force --options runtime --sign "$IDENTITY" "$f"
+          done
+
+          # Sign the main app
+          codesign \
+            --force \
+            --options runtime \
+            --entitlements Entitlements.plist \
+            --sign "$IDENTITY" \
+            "$APP_BUNDLE"
+
+          # Verify
+          codesign --verify --deep --strict "$APP_BUNDLE"
+          echo "Signing OK"
 
       - name: Create DMG
         run: |
@@ -72,12 +133,10 @@ jobs:
           APP_BUNDLE="$DISPLAY_NAME.app"
           DMG_NAME="Hermes-Agent-${GITHUB_REF_NAME}.dmg"
 
-          # Create a temporary directory for the DMG contents
           mkdir -p dmg-staging
           cp -r "$APP_BUNDLE" dmg-staging/
           ln -s /Applications dmg-staging/Applications
 
-          # Create the DMG
           hdiutil create -volname "Hermes Agent" \
             -srcfolder dmg-staging \
             -ov -format UDZO \
@@ -86,19 +145,77 @@ jobs:
           rm -rf dmg-staging
           echo "DMG_NAME=$DMG_NAME" >> $GITHUB_ENV
 
+      - name: Sign DMG
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          codesign --force --sign "Developer ID Application" "${{ env.DMG_NAME }}"
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool submit "${{ env.DMG_NAME }}" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+      - name: Staple notarization ticket
+        run: |
+          xcrun stapler staple "${{ env.DMG_NAME }}"
+          xcrun stapler validate "${{ env.DMG_NAME }}"
+          echo "Notarization and stapling OK"
+
+      - name: Generate Sparkle ed25519 signature
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          # Download Sparkle tools matching the version used by the app
+          SPARKLE_VERSION=$(swift package show-dependencies --format json | python3 -c "
+          import json,sys
+          deps = json.load(sys.stdin)
+          for d in deps.get('dependencies', []):
+              if 'sparkle' in d.get('url','').lower():
+                  print(d['version'])
+                  break
+          " 2>/dev/null || echo "2.9.1")
+
+          curl -L "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz" \
+            -o sparkle-tools.tar.xz
+          mkdir -p sparkle-tools
+          tar -xf sparkle-tools.tar.xz -C sparkle-tools
+
+          # sign_update reads the private key from the SPARKLE_PRIVATE_KEY env var
+          SIG=$(echo "$SPARKLE_PRIVATE_KEY" | sparkle-tools/bin/sign_update "${{ env.DMG_NAME }}" -f -)
+          SIZE=$(stat -f%z "${{ env.DMG_NAME }}")
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          echo "SPARKLE_SIG=$SIG" >> $GITHUB_ENV
+          echo "SPARKLE_SIZE=$SIZE" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+          echo "Sparkle signature: $SIG"
+          echo "DMG size: $SIZE bytes"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.DMG_NAME }}
           generate_release_notes: true
           body: |
-            ## Hermes Agent for macOS
+            ## Hermes Agent for macOS — ${{ env.RELEASE_VERSION }}
 
             Download `${{ env.DMG_NAME }}`, open the DMG, and drag **Hermes Agent** to your Applications folder.
 
-            **First launch:** macOS may show a Gatekeeper warning since the app is not signed. Right-click the app and choose "Open", or run:
-            ```bash
-            xattr -dr com.apple.quarantine "/Applications/Hermes Agent.app"
-            ```
+            This release is signed with a Developer ID certificate and notarized by Apple.
+            macOS will open it without any Gatekeeper warning.
 
             **Requirements:** macOS 12+ (Monterey or later)
+
+            ---
+            <!-- Sparkle appcast metadata (do not remove) -->
+            <!-- sparkle:edSignature: ${{ env.SPARKLE_SIG }} -->
+            <!-- sparkle:length: ${{ env.SPARKLE_SIZE }} -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v1.0.4] — 2026-04-16
+
+### Added
+- Sparkle 2 auto-update support — app now checks `https://get-hermes.ai/appcast.xml` on launch and shows a native update dialog when a new version is available. A "Check for Updates…" menu item is available under the app menu at any time. (PR #21, closes #17)
+- `Entitlements.plist` — hardened runtime entitlements for network access and microphone. Required for notarization. App remains unsandboxed so SSH tunnel (NSTask) continues to work. (PR #21)
+- `appcast.xml` template in repo root — Sparkle update feed published at `https://get-hermes.ai/appcast.xml`. (PR #21)
+
+### Fixed
+- WKWebView navigation guard — external links (any http/https URL that is not localhost or the configured SSH host) now open in Safari instead of navigating inside the app. `file://` URLs are blocked entirely. (PR #21, closes #7)
+
+### Changed
+- CI release workflow now imports a Developer ID Application certificate, signs the app with hardened runtime, notarizes via `notarytool`, and staples the ticket to the DMG. Users on v1.0.4+ will no longer see the Gatekeeper "unidentified developer" warning on first launch. (PR #21)
+- CI generates a Sparkle ed25519 signature for each DMG and embeds it in the release notes for appcast maintenance. (PR #21)
+
 ## [v1.0.3] — 2026-04-16
 
 ### Added

--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Network access for SSH tunnel, WebUI, and Sparkle update checks -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <!-- Microphone for voice input in the chat interface -->
+    <key>com.apple.security.device.microphone</key>
+    <true/>
+    <!-- No sandbox — required for SSH tunnel subprocess (NSTask) -->
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,18 @@ import PackageDescription
 let package = Package(
     name: "HermesAgent",
     platforms: [.macOS(.v12)],
+    dependencies: [
+        .package(
+            url: "https://github.com/sparkle-project/Sparkle",
+            from: "2.0.0"
+        ),
+    ],
     targets: [
         .executableTarget(
             name: "HermesAgent",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle"),
+            ],
             path: "Sources/HermesAgent"
         ),
         .testTarget(

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -22,15 +22,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 
-        // Initialize Sparkle updater — feed URL set in code (also in Info.plist as belt-and-suspenders)
+        // Initialize Sparkle updater — feed URL comes from SUFeedURL in Info.plist
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
-        if let feedURL = URL(string: "https://get-hermes.ai/appcast.xml") {
-            updaterController.updater.feedURL = feedURL
-        }
 
         setupMenu()
         seedDefaultsIfNeeded()

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Cocoa
+import Sparkle
 
 class AppDelegate: NSObject, NSApplicationDelegate {
 
@@ -15,10 +16,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var splashWindow: SplashWindowController!
     var browserWindow: BrowserWindowController?
     var preferencesWindow: PreferencesWindowController?
+    var updaterController: SPUStandardUpdaterController!
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
+
+        // Initialize Sparkle updater — feed URL set in code (also in Info.plist as belt-and-suspenders)
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+        if let feedURL = URL(string: "https://get-hermes.ai/appcast.xml") {
+            updaterController.updater.feedURL = feedURL
+        }
+
         setupMenu()
         seedDefaultsIfNeeded()
         requestMicrophonePermission()
@@ -46,7 +59,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-
     func seedDefaultsIfNeeded() {
         let defaults = UserDefaults.standard
         if defaults.string(forKey: "sshUser") == nil {
@@ -72,7 +84,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         tunnelManager?.stop()
 
         if connectionMode == "ssh" {
-            // SSH tunnel mode
             let user = defaults.string(forKey: "sshUser") ?? defaultSSHUser
             let host = defaults.string(forKey: "sshHost") ?? defaultSSHHost
             let localPort = Int(defaults.string(forKey: "localPort") ?? defaultLocalPort) ?? 8787
@@ -108,7 +119,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         } else {
-            // Direct mode (local)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.splashWindow.close()
                 let browser = BrowserWindowController(
@@ -135,6 +145,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         appMenu.addItem(
             withTitle: "About \(appTitle)",
             action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(.separator())
+        appMenu.addItem(
+            withTitle: "Check for Updates…",
+            action: #selector(checkForUpdates),
+            keyEquivalent: "")
         appMenu.addItem(.separator())
         appMenu.addItem(
             withTitle: "Preferences…", action: #selector(openPreferences), keyEquivalent: ",")
@@ -167,6 +182,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             withTitle: "Zoom", action: #selector(NSWindow.zoom(_:)), keyEquivalent: "")
 
         NSApp.mainMenu = menuBar
+    }
+
+    @objc func checkForUpdates() {
+        updaterController.checkForUpdates(nil)
     }
 
     @objc func openPreferences() {

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -277,6 +277,57 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         }
     }
 
+    // MARK: - Navigation guard (issue #7)
+    // Allow only localhost/127.0.0.1 navigation. All other http/https links open in
+    // Safari. file:// is blocked entirely.
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        let scheme = url.scheme?.lowercased() ?? ""
+
+        // Block file:// entirely
+        if scheme == "file" {
+            decisionHandler(.cancel)
+            return
+        }
+
+        // Allow non-http(s) schemes (about:, blob:, data:, etc.) — WebKit needs these internally
+        guard scheme == "http" || scheme == "https" else {
+            decisionHandler(.allow)
+            return
+        }
+
+        let host = url.host?.lowercased() ?? ""
+
+        // Allow localhost and loopback
+        if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+            decisionHandler(.allow)
+            return
+        }
+
+        // Allow navigation to the configured remote host (SSH mode)
+        let configuredURL = UserDefaults.standard.string(forKey: "targetURL") ?? ""
+        if let configuredHost = URL(string: configuredURL)?.host?.lowercased(),
+            !configuredHost.isEmpty,
+            host == configuredHost
+        {
+            decisionHandler(.allow)
+            return
+        }
+
+        // Everything else opens in Safari
+        NSWorkspace.shared.open(url)
+        decisionHandler(.cancel)
+    }
+
     // MARK: - Window focus
 
     func windowDidBecomeKey(_ notification: Notification) {

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymaurer.ch/developer/sparkle/rss/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Hermes Agent Updates</title>
+        <link>https://get-hermes.ai/appcast.xml</link>
+        <description>Hermes Agent changelog and update feed</description>
+        <language>en</language>
+
+        <item>
+            <title>Version 1.0.3</title>
+            <pubDate>Thu, 16 Apr 2026 18:55:47 +0000</pubDate>
+            <sparkle:version>1.0.3</sparkle:version>
+            <sparkle:shortVersionString>1.0.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+            <enclosure
+                url="https://github.com/hermes-webui/hermes-swift-mac/releases/download/v1.0.3/Hermes-Agent-v1.0.3.dmg"
+                sparkle:edSignature="PLACEHOLDER_SIGNATURE_1_0_3"
+                length="PLACEHOLDER_SIZE_1_0_3"
+                type="application/octet-stream"/>
+        </item>
+
+    </channel>
+</rss>

--- a/build.sh
+++ b/build.sh
@@ -13,8 +13,22 @@ echo "→ Bundling $APP_BUNDLE..."
 rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
+mkdir -p "$APP_BUNDLE/Contents/Frameworks"
 
 cp "$BUILD_DIR/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/"
+
+echo "→ Embedding Sparkle.framework..."
+SPARKLE_FW=$(find .build/artifacts -name "Sparkle.framework" -maxdepth 6 | head -1)
+if [ -z "$SPARKLE_FW" ]; then
+    echo "Error: Sparkle.framework not found in .build/artifacts — run 'swift package resolve' first"
+    exit 1
+fi
+cp -R "$SPARKLE_FW" "$APP_BUNDLE/Contents/Frameworks/"
+
+# Fix rpath so the binary can find the embedded framework at runtime
+install_name_tool \
+    -add_rpath "@executable_path/../Frameworks" \
+    "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 
 echo "→ Converting icon..."
 ICONSET="AppIcon.iconset"
@@ -59,11 +73,17 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <false/>
     <key>NSMicrophoneUsageDescription</key>
     <string>Hermes Agent uses the microphone for voice input in the chat interface.</string>
+    <key>SUPublicEDKey</key>
+    <string>daAlTqdBbYPSCDjS9IfTCJOFDo1jqtjMRZluhtAbKMY=</string>
+    <key>SUFeedURL</key>
+    <string>https://get-hermes.ai/appcast.xml</string>
 </dict>
 </plist>
 PLIST
 
 echo "→ Signing (ad-hoc)..."
+# Sign the framework first, then the app
+codesign --force --deep --sign - "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 codesign --force --deep --sign - "$APP_BUNDLE"
 
 echo "→ Installing to Applications..."
@@ -73,7 +93,7 @@ cp -r "$APP_BUNDLE" "/Applications/$APP_BUNDLE"
 echo "→ Installed to /Applications/$APP_BUNDLE"
 echo "Note: icon cache refresh is optional and may require sudo if the old icon persists."
 echo "If needed, run these commands manually:"
-echo "  sudo find /private/var/folders -name \"com.apple.dock.iconcache\" -exec rm {} \; 2>/dev/null || true"
+echo "  sudo find /private/var/folders -name \"com.apple.dock.iconcache\" -exec rm {} \\; 2>/dev/null || true"
 echo "  sudo rm -rf /Library/Caches/com.apple.iconservices.store 2>/dev/null || true"
 echo "  killall Dock"
 echo "  killall Finder"


### PR DESCRIPTION
## What this does

Closes #17, closes #7.

### Sparkle 2 auto-update
- Adds Sparkle 2 as a SwiftPM dependency
- Wires `SPUStandardUpdaterController` in AppDelegate with feed URL `https://get-hermes.ai/appcast.xml`
- Adds **Check for Updates…** menu item under the app menu
- `SUPublicEDKey` and `SUFeedURL` embedded in Info.plist via CI workflow

### Developer ID signing + notarization
- New `Entitlements.plist` (network client + microphone, no sandbox — required for SSH tunnel)
- CI workflow updated to import Developer ID cert, sign with hardened runtime, notarize via `notarytool`, and staple the ticket
- Users will no longer see the Gatekeeper warning on first launch

### Sparkle appcast support
- CI generates the ed25519 signature for each DMG using `sign_update`
- `appcast.xml` template added to repo root (needs to be published to get-hermes.ai/appcast.xml — next step)

### WKWebView navigation guard (#7)
- `decidePolicyFor navigationAction` implemented in BrowserWindowController
- localhost and 127.0.0.1 allowed through
- Configured remote host (SSH mode) allowed through
- All other http/https URLs open in Safari via NSWorkspace
- `file://` blocked entirely

## GitHub secrets required (all 6 already added)
- `DEVELOPER_ID_APPLICATION_CERT_P12`
- `DEVELOPER_ID_CERT_PASSWORD`
- `APPLE_ID`
- `APPLE_ID_PASSWORD`
- `APPLE_TEAM_ID`
- `SPARKLE_PRIVATE_KEY`

## What's still needed after merge
1. Build locally on a Mac to verify Sparkle.framework embeds correctly
2. Publish appcast.xml to the gh-pages branch (get-hermes.ai/appcast.xml)
3. Tag v2.0.0 to trigger the first fully signed+notarized release