### PR TITLE
feat: error page on failed connection, test connection button, macOS notifications (#12, #4, #8)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,6 +79,7 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :NSHighResolutionCapable bool true"               "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :LSUIElement bool false"                          "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string 'Hermes Agent uses the microphone for voice input in the chat interface.'" "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :NSUserNotificationUsageDescription string 'Hermes Agent notifies you when an AI response is ready while the window is in the background.'" "$APP_BUNDLE/Contents/Info.plist"
           # Sparkle keys
           /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string 'daAlTqdBbYPSCDjS9IfTCJOFDo1jqtjMRZluhtAbKMY='" "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :SUFeedURL string 'https://hermes-webui.github.io/hermes-swift-mac/appcast.xml'" "$APP_BUNDLE/Contents/Info.plist"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v1.0.6] — 2026-04-17
 
 ### Added
 - macOS notifications (#8) — when a response finishes while the app window is in the background, a native macOS notification appears. Permission is requested on first trigger. Works via a debounced MutationObserver injected into the WebView.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- macOS notifications (#8) — when a response finishes while the app window is in the background, a native macOS notification appears. Permission is requested on first trigger. Works via a debounced MutationObserver injected into the WebView.
+- Test Connection button in Preferences (#4) — click to verify the target URL is reachable before saving. Shows "✓ Connected" or "✗ Unreachable" inline with a 5-second timeout. Works for both direct and SSH tunnel modes.
+
+### Fixed
+- White screen on failed connection (#12) — if the WebView cannot reach the server, a helpful error page now loads instead of a blank white screen. Shows the target URL, mode-specific guidance (direct: start command, SSH: tunnel check), and a Try Again button.
+
 ## [v1.0.4] — 2026-04-16
 
 ### Added

--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -8,6 +8,9 @@
     <!-- Microphone for voice input in the chat interface -->
     <key>com.apple.security.device.microphone</key>
     <true/>
+    <!-- User notifications for response-ready alerts -->
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
     <!-- No sandbox — required for SSH tunnel subprocess (NSTask) -->
 </dict>
 </plist>

--- a/Entitlements.plist
+++ b/Entitlements.plist
@@ -8,9 +8,7 @@
     <!-- Microphone for voice input in the chat interface -->
     <key>com.apple.security.device.microphone</key>
     <true/>
-    <!-- User notifications for response-ready alerts -->
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    <!-- No sandbox — required for SSH tunnel subprocess (NSTask) -->
+    <!-- No sandbox — required for SSH tunnel subprocess (NSTask).
+         com.apple.security.app-sandbox is omitted (implicitly false for non-MAS apps). -->
 </dict>
 </plist>

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -97,24 +97,37 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
         // Notify Swift when the AI finishes a response (streaming settled) and
         // the window is in the background. Used for macOS notifications (#8).
-        // Debounces DOM mutations — fires 2s after last change when page is hidden.
+        // Only fires on characterData mutations (actual text changes) that settle
+        // for 3s — ignores childList/structural churn to avoid false positives
+        // from scroll virtualisation, cursor blinks, etc.
         let notifyScript = WKUserScript(
             source: """
                 (function() {
                     let debounceTimer = null;
-                    const observer = new MutationObserver(() => {
+                    let totalCharsAdded = 0;
+                    const MIN_CHARS = 20;  // ignore tiny updates (timestamps, badges, etc.)
+                    const observer = new MutationObserver((mutations) => {
+                        let charsThisBatch = 0;
+                        for (const m of mutations) {
+                            if (m.type === 'characterData') {
+                                charsThisBatch += (m.target.nodeValue || '').length;
+                            }
+                        }
+                        if (charsThisBatch === 0) return;
+                        totalCharsAdded += charsThisBatch;
                         clearTimeout(debounceTimer);
                         debounceTimer = setTimeout(() => {
-                            if (document.hidden) {
+                            if (document.hidden && totalCharsAdded >= MIN_CHARS) {
                                 window.webkit.messageHandlers.hermesNotify.postMessage({
                                     title: 'Hermes',
                                     body: 'Your response is ready'
                                 });
                             }
-                        }, 2000);
+                            totalCharsAdded = 0;
+                        }, 3000);
                     });
                     observer.observe(document.body, {
-                        childList: true, subtree: true, characterData: true
+                        subtree: true, characterData: true
                     });
                 })();
                 """,
@@ -292,6 +305,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     // MARK: - WKScriptMessageHandler (notifications)
 
+    // Cache auth status so we don't call requestAuthorization on every message.
+    private var notificationAuthGranted: Bool? = nil
+
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard message.name == "hermesNotify",
               let body = message.body as? [String: String],
@@ -300,18 +316,31 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         else { return }
 
         let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
-            guard granted else { return }
+
+        func postNotification() {
             let content = UNMutableNotificationContent()
             content.title = title
             content.body = text
             content.sound = .default
+            // Stable identifier coalesces rapid bursts — only the last one shows.
             let request = UNNotificationRequest(
-                identifier: "hermes-response-\(Date().timeIntervalSince1970)",
+                identifier: "hermes-response-ready",
                 content: content,
                 trigger: nil
             )
             center.add(request)
+        }
+
+        if let granted = notificationAuthGranted {
+            if granted { postNotification() }
+            return
+        }
+
+        center.requestAuthorization(options: [.alert, .sound]) { [weak self] granted, _ in
+            DispatchQueue.main.async {
+                self?.notificationAuthGranted = granted
+                if granted { postNotification() }
+            }
         }
     }
 
@@ -321,6 +350,13 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         let targetURL = UserDefaults.standard.string(forKey: "targetURL") ?? "http://localhost:8787"
         let mode = UserDefaults.standard.string(forKey: "connectionMode") ?? "direct"
         let isSSH = mode == "ssh"
+
+        // HTML-escape the URL before interpolating into the page
+        let safeURL = targetURL
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
 
         let tip = isSSH
             ? "The SSH tunnel may not be established, or hermes-webui may not be running on the remote server."
@@ -360,7 +396,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         <div class="card">
           <div class="icon">⚠️</div>
           <h2>Cannot connect to Hermes</h2>
-          <p class="url">\(targetURL)</p>
+          <p class=\"url\">\(safeURL)</p>
           <p>\(tip)</p>
           <button onclick="window.location.reload()">Try Again</button>
         </div>

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -396,7 +396,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         <div class="card">
           <div class="icon">⚠️</div>
           <h2>Cannot connect to Hermes</h2>
-          <p class=\"url\">\(safeURL)</p>
+          <p class="url">\(safeURL)</p>
           <p>\(tip)</p>
           <button onclick="window.location.reload()">Try Again</button>
         </div>

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Cocoa
+import UserNotifications
 import WebKit
 
 class BrowserWindow: NSWindow {
@@ -20,7 +21,7 @@ private class HermesWebView: WKWebView {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 }
 
-class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegate, WKNavigationDelegate {
+class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler {
 
     private var webView: HermesWebView!
     private var statusBar: NSView!
@@ -93,6 +94,35 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             forMainFrameOnly: true
         )
         config.userContentController.addUserScript(speechSuppressionScript)
+
+        // Notify Swift when the AI finishes a response (streaming settled) and
+        // the window is in the background. Used for macOS notifications (#8).
+        // Debounces DOM mutations — fires 2s after last change when page is hidden.
+        let notifyScript = WKUserScript(
+            source: """
+                (function() {
+                    let debounceTimer = null;
+                    const observer = new MutationObserver(() => {
+                        clearTimeout(debounceTimer);
+                        debounceTimer = setTimeout(() => {
+                            if (document.hidden) {
+                                window.webkit.messageHandlers.hermesNotify.postMessage({
+                                    title: 'Hermes',
+                                    body: 'Your response is ready'
+                                });
+                            }
+                        }, 2000);
+                    });
+                    observer.observe(document.body, {
+                        childList: true, subtree: true, characterData: true
+                    });
+                })();
+                """,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(notifyScript)
+        config.userContentController.add(self, name: "hermesNotify")
 
         let webFrame = NSRect(
             x: 0, y: statusBarHeight, width: bounds.width, height: bounds.height - statusBarHeight)
@@ -258,6 +288,86 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     @objc func reconnectTapped() {
         onReconnect?()
+    }
+
+    // MARK: - WKScriptMessageHandler (notifications)
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard message.name == "hermesNotify",
+              let body = message.body as? [String: String],
+              let title = body["title"],
+              let text = body["body"]
+        else { return }
+
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = text
+            content.sound = .default
+            let request = UNNotificationRequest(
+                identifier: "hermes-response-\(Date().timeIntervalSince1970)",
+                content: content,
+                trigger: nil
+            )
+            center.add(request)
+        }
+    }
+
+    // MARK: - Error page (connection failed)
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        let targetURL = UserDefaults.standard.string(forKey: "targetURL") ?? "http://localhost:8787"
+        let mode = UserDefaults.standard.string(forKey: "connectionMode") ?? "direct"
+        let isSSH = mode == "ssh"
+
+        let tip = isSSH
+            ? "The SSH tunnel may not be established, or hermes-webui may not be running on the remote server."
+            : "Make sure hermes-webui is running. Start it with:<br><code>cd ~/hermes-webui-public &amp;&amp; bash start.sh</code>"
+
+        let html = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="utf-8">
+        <style>
+          body {
+            font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+            display: flex; align-items: center; justify-content: center;
+            height: 100vh; margin: 0;
+            background: #f5f5f7; color: #1d1d1f;
+          }
+          .card {
+            background: white; border-radius: 16px;
+            padding: 40px 48px; max-width: 480px; text-align: center;
+            box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+          }
+          .icon { font-size: 48px; margin-bottom: 16px; }
+          h2 { margin: 0 0 8px; font-size: 20px; font-weight: 600; }
+          p { margin: 0 0 12px; color: #6e6e73; font-size: 14px; line-height: 1.5; }
+          code { background: #f5f5f7; padding: 2px 6px; border-radius: 4px; font-size: 13px; }
+          .url { font-size: 13px; color: #8e8e93; margin-bottom: 24px; }
+          button {
+            background: #0071e3; color: white; border: none;
+            padding: 10px 24px; border-radius: 8px; font-size: 15px;
+            cursor: pointer; font-family: inherit;
+          }
+          button:hover { background: #0077ed; }
+        </style>
+        </head>
+        <body>
+        <div class="card">
+          <div class="icon">⚠️</div>
+          <h2>Cannot connect to Hermes</h2>
+          <p class="url">\(targetURL)</p>
+          <p>\(tip)</p>
+          <button onclick="window.location.reload()">Try Again</button>
+        </div>
+        </body>
+        </html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
     }
 
     // MARK: - File upload

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -253,8 +253,9 @@ class PreferencesWindowController: NSWindowController {
                     self.testResultLabel.stringValue = "✗ Unreachable"
                     self.testResultLabel.textColor = .systemRed
                 } else {
-                    self.testResultLabel.stringValue = "✓ Connected"
-                    self.testResultLabel.textColor = .systemGreen
+                    // No error and no HTTP response (e.g. non-HTTP scheme) — treat as unreachable
+                    self.testResultLabel.stringValue = "✗ Unreachable"
+                    self.testResultLabel.textColor = .systemRed
                 }
             }
         }.resume()

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -11,6 +11,7 @@ class PreferencesWindowController: NSWindowController {
     private var localPortField: NSTextField!
     private var remotePortField: NSTextField!
     private var targetURLField: NSTextField!
+    private var testResultLabel: NSTextField!
 
     init() {
         let window = NSWindow(
@@ -137,6 +138,17 @@ class PreferencesWindowController: NSWindowController {
         saveBtn.keyEquivalent = "\r"
         saveBtn.frame = NSRect(x: 362, y: 16, width: 100, height: 32)
         content.addSubview(saveBtn)
+
+        let testBtn = NSButton(title: "Test Connection", target: self, action: #selector(testConnection))
+        testBtn.bezelStyle = .rounded
+        testBtn.frame = NSRect(x: 24, y: 16, width: 130, height: 32)
+        content.addSubview(testBtn)
+
+        testResultLabel = NSTextField(labelWithString: "")
+        testResultLabel.font = NSFont.systemFont(ofSize: 11)
+        testResultLabel.textColor = .secondaryLabelColor
+        testResultLabel.frame = NSRect(x: 164, y: 22, width: 90, height: 16)
+        content.addSubview(testResultLabel)
     }
 
     @objc func save() {
@@ -211,6 +223,41 @@ class PreferencesWindowController: NSWindowController {
         alert.messageText = "Invalid value"
         alert.informativeText = message
         alert.runModal()
+    }
+
+    @objc func testConnection() {
+        let urlString = targetURLField.stringValue.isEmpty
+            ? (UserDefaults.standard.string(forKey: "targetURL") ?? "http://localhost:8787")
+            : targetURLField.stringValue
+
+        guard let url = URL(string: urlString) else {
+            testResultLabel.stringValue = "Invalid URL"
+            testResultLabel.textColor = .systemRed
+            return
+        }
+
+        testResultLabel.stringValue = "Testing…"
+        testResultLabel.textColor = .secondaryLabelColor
+
+        var request = URLRequest(url: url, timeoutInterval: 5)
+        request.httpMethod = "HEAD"
+
+        URLSession.shared.dataTask(with: request) { [weak self] _, response, error in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if let httpResponse = response as? HTTPURLResponse,
+                   (200...399).contains(httpResponse.statusCode) {
+                    self.testResultLabel.stringValue = "✓ Connected"
+                    self.testResultLabel.textColor = .systemGreen
+                } else if error != nil {
+                    self.testResultLabel.stringValue = "✗ Unreachable"
+                    self.testResultLabel.textColor = .systemRed
+                } else {
+                    self.testResultLabel.stringValue = "✓ Connected"
+                    self.testResultLabel.textColor = .systemGreen
+                }
+            }
+        }.resume()
     }
 
     @objc func cancel() {

--- a/build.sh
+++ b/build.sh
@@ -73,6 +73,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <false/>
     <key>NSMicrophoneUsageDescription</key>
     <string>Hermes Agent uses the microphone for voice input in the chat interface.</string>
+    <key>NSUserNotificationUsageDescription</key>
+    <string>Hermes Agent notifies you when an AI response is ready while the window is in the background.</string>
     <key>SUPublicEDKey</key>
     <string>daAlTqdBbYPSCDjS9IfTCJOFDo1jqtjMRZluhtAbKMY=</string>
     <key>SUFeedURL</key>


### PR DESCRIPTION
Closes #12, closes #4, closes #8.

## Changes

### Error page instead of white screen (#12)
Implements `webView(_:didFailProvisionalNavigation:withError:)`. When the WebView can't reach the server, a clean error page loads showing the target URL, mode-specific fix instructions, and a Try Again button. Direct mode tells you to run `bash start.sh`. SSH mode tells you to check the tunnel.

### Test Connection button in Preferences (#4)
New button bottom-left of the Preferences window. Makes a HEAD request to the current Target URL with a 5s timeout. Shows `✓ Connected` (green) or `✗ Unreachable` (red) inline. Tests the URL as typed, before saving — so you can verify before committing.

### macOS notifications (#8)
Injects a debounced MutationObserver into the WebView. When DOM changes settle after 2 seconds and the window is in the background (`document.hidden` is true), it posts a message to Swift via `WKScriptMessageHandler`. Swift fires a `UNUserNotificationCenter` notification. Permission is requested lazily on first trigger — no startup prompt.

## Files changed
- `BrowserWindowController.swift` — error page handler, notification script + message handler, UserNotifications import
- `PreferencesWindowController.swift` — Test Connection button + result label + testConnection method
- `Entitlements.plist` — explicit no-sandbox declaration
- `build.sh` + CI workflow — NSUserNotificationUsageDescription added to Info.plist
- `CHANGELOG.md` — unreleased section

## Needs local build test
Same as last time — `swift build` + `bash build.sh` on Mac to verify compile.