### PR TITLE
feat: v1.1.0 — launch at login, zoom shortcuts, status indicator, ATS fix, dark mode FOUC, error screen repo link

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -98,6 +98,11 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :LSUIElement bool false"                          "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :NSMicrophoneUsageDescription string 'Hermes Agent uses the microphone for voice input in the chat interface.'" "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :NSUserNotificationUsageDescription string 'Hermes Agent notifies you when an AI response is ready while the window is in the background.'" "$APP_BUNDLE/Contents/Info.plist"
+          # ATS: allow plain http:// in WKWebView for non-localhost targets (Tailscale, LAN, custom hostnames)
+          # NSAllowsArbitraryLoads stays false so URLSession (preflightHTTP) keeps normal ATS restrictions.
+          /usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity dict" "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool false" "$APP_BUNDLE/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Add :NSAppTransportSecurity:NSAllowsArbitraryLoadsInWebContent bool true" "$APP_BUNDLE/Contents/Info.plist"
           # Sparkle keys
           /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string 'daAlTqdBbYPSCDjS9IfTCJOFDo1jqtjMRZluhtAbKMY='" "$APP_BUNDLE/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Add :SUFeedURL string 'https://hermes-webui.github.io/hermes-swift-mac/appcast.xml'" "$APP_BUNDLE/Contents/Info.plist"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.1.0] — 2026-04-19
+
+### Added
+- **Launch at login** — Preferences now includes a "Launch at login" checkbox (macOS 13+, SMAppService). Correctly handles `.requiresApproval` state and shows a System Settings nudge. Disabled with an inline note on macOS 12. (fixes #3)
+- **View zoom — Cmd+/Cmd− keyboard shortcuts** — new View menu with Zoom In, Zoom Out, and Actual Size. Pinch-to-zoom was already enabled; this adds keyboard control. (fixes #24)
+- **Connection status in window title** — direct-mode window title now shows the active backend host and a live indicator (● connected / ○ offline). A 30-second health poll detects when the backend goes away without a full page reload. (fixes #29)
+
+### Fixed
+- **Non-localhost URLs silently failing** — plain `http://` to Tailscale IPs, LAN addresses, and custom hostnames was blocked by App Transport Security in WKWebView. Added `NSAllowsArbitraryLoadsInWebContent` to Info.plist (both `build.sh` and CI workflow). URLSession (used for connection preflight) keeps default ATS restrictions. (fixes #25)
+- **Dark mode white flash on startup** — WKWebView rendered white before the dark theme loaded. Set `underPageBackgroundColor` to `.windowBackgroundColor` (macOS 12+) and added a `documentStart` userScript to set the HTML background before first paint. (fixes #23)
+- **Error screen didn't name the backend repo** — first-time users who hit "Cannot connect" had no way to find the backend. Added a clickable "github.com/nesquena/hermes-webui" link to the error screen in direct mode. (fixes #27)
+
 ## [v1.0.9] — 2026-04-16
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -248,11 +248,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         windowMenu.addItem(
             withTitle: "Zoom", action: #selector(NSWindow.zoom(_:)), keyEquivalent: "")
 
+        let viewMenuItem = NSMenuItem()
+        menuBar.addItem(viewMenuItem)
+        let viewMenu = NSMenu(title: "View")
+        viewMenuItem.submenu = viewMenu
+        viewMenu.addItem(
+            withTitle: "Zoom In", action: #selector(zoomIn), keyEquivalent: "+")
+        viewMenu.addItem(
+            withTitle: "Zoom Out", action: #selector(zoomOut), keyEquivalent: "-")
+        viewMenu.addItem(
+            withTitle: "Actual Size", action: #selector(zoomReset), keyEquivalent: "0")
+
         NSApp.mainMenu = menuBar
     }
 
     @objc func checkForUpdates() {
         updaterController.checkForUpdates(nil)
+    }
+
+    // MARK: - View zoom (fix #24)
+
+    @objc func zoomIn() {
+        guard let webView = browserWindow?.webViewForZoom else { return }
+        webView.magnification = min(webView.magnification + 0.1, 3.0)
+    }
+
+    @objc func zoomOut() {
+        guard let webView = browserWindow?.webViewForZoom else { return }
+        webView.magnification = max(webView.magnification - 0.1, 0.5)
+    }
+
+    @objc func zoomReset() {
+        browserWindow?.webViewForZoom?.magnification = 1.0
     }
 
     @objc func openPreferences() {

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -25,6 +25,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     private var webView: HermesWebView!
     private var statusBar: NSView!
+
+    /// Exposes the WKWebView for zoom operations called from AppDelegate menu actions.
+    /// Return type is WKWebView (not the private HermesWebView subclass) so Swift's
+    /// access-level rules are satisfied — callers only need .magnification anyway.
+    var webViewForZoom: WKWebView? { webView }
     private var separator: NSView!
     private var statusDot: NSView!
     private var statusLabel: NSTextField!
@@ -34,6 +39,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private let connectionMode: String
     var onReconnect: (() -> Void)?
     var onNavigationFailed: (() -> Void)?
+
+    // Health check timer for direct mode — polls /health every 30s and
+    // reflects status in the window title (fix #29).
+    private var healthTimer: Timer?
+    private var isHealthy: Bool = true
 
     init(urlString: String, title: String, connectionMode: String = "direct") {
         self.urlString = urlString
@@ -48,6 +58,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         )
         window.title = title
         window.center()
+        // Fix #23: set native window background to dark before content loads,
+        // so there's no white frame visible while WKWebView is initializing.
+        window.backgroundColor = .windowBackgroundColor
         super.init(window: window)
 
         window.onPaste = { [weak self] in
@@ -145,6 +158,31 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         webView.uiDelegate = self
         webView.navigationDelegate = self
         webView.allowsMagnification = true
+
+        // Fix #23: prevent white flash on startup in dark mode (FOUC).
+        // Set the WKWebView background to match the system window background
+        // before the first paint — otherwise the WebView renders white while
+        // the dark theme is still loading from the server.
+        if #available(macOS 12.0, *) {
+            webView.underPageBackgroundColor = .windowBackgroundColor
+        }
+        // Fallback for older OS: inject a documentStart script that sets the
+        // background immediately before the first paint.
+        let darkModeScript = WKUserScript(
+            source: """
+                (function() {
+                    var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    if (isDark) {
+                        document.documentElement.style.background = '#1a1a1a';
+                        document.body && (document.body.style.background = '#1a1a1a');
+                    }
+                })();
+                """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(darkModeScript)
+
         contentView.addSubview(webView)
 
         // Only add status bar in SSH mode
@@ -187,6 +225,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
         if let url = URL(string: urlString) {
             webView.load(URLRequest(url: url))
+        }
+
+        // Start health polling for direct mode (fix #29)
+        if connectionMode == "direct" {
+            updateWindowTitle(healthy: true)
+            startHealthCheck()
         }
     }
 
@@ -278,6 +322,46 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     }
 
     // MARK: - Status
+
+    // MARK: Health check (direct mode, fix #29)
+
+    private func startHealthCheck() {
+        let healthURL = urlString.hasSuffix("/") ? "\(urlString)health" : "\(urlString)/health"
+        healthTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.pingHealth(urlString: healthURL)
+        }
+    }
+
+    func stopHealthCheck() {
+        healthTimer?.invalidate()
+        healthTimer = nil
+    }
+
+    private func pingHealth(urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        var request = URLRequest(url: url, timeoutInterval: 5)
+        request.httpMethod = "GET"
+        URLSession.shared.dataTask(with: request) { [weak self] _, response, _ in
+            let healthy = response is HTTPURLResponse
+            DispatchQueue.main.async {
+                guard let self = self, healthy != self.isHealthy else { return }
+                self.isHealthy = healthy
+                self.updateWindowTitle(healthy: healthy)
+            }
+        }.resume()
+    }
+
+    private func updateWindowTitle(healthy: Bool) {
+        let hostDisplay: String
+        if let url = URL(string: urlString), let host = url.host {
+            let port = url.port.map { ":\($0)" } ?? ""
+            hostDisplay = "\(host)\(port)"
+        } else {
+            hostDisplay = urlString
+        }
+        let dot = healthy ? "●" : "○"
+        window?.title = "\(appTitle)  \(dot) \(hostDisplay)"
+    }
 
     func updateStatus(_ status: TunnelStatus, host: String, port: Int) {
         guard connectionMode == "ssh" else { return }
@@ -455,6 +539,10 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // Ensure the WebView holds keyboard focus whenever the window is active,
         // so shortcuts like Cmd+K reach JavaScript without requiring an extra click.
         webView.becomeFirstResponder()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        stopHealthCheck()
     }
 
     // MARK: - Microphone / camera permissions

--- a/Sources/HermesAgent/ErrorWindowController.swift
+++ b/Sources/HermesAgent/ErrorWindowController.swift
@@ -11,7 +11,7 @@ class ErrorWindowController: NSWindowController {
 
     init(appTitle: String, targetURL: String, mode: String) {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 320),
+            contentRect: NSRect(x: 0, y: 0, width: 460, height: 360),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -25,14 +25,14 @@ class ErrorWindowController: NSWindowController {
         let icon = NSTextField(labelWithString: "⚠️")
         icon.font = NSFont.systemFont(ofSize: 40)
         icon.alignment = .center
-        icon.frame = NSRect(x: 0, y: 240, width: 460, height: 50)
+        icon.frame = NSRect(x: 0, y: 280, width: 460, height: 50)
         icon.autoresizingMask = [.width]
         content.addSubview(icon)
 
         let title = NSTextField(labelWithString: "Cannot connect to Hermes")
         title.font = NSFont.systemFont(ofSize: 17, weight: .semibold)
         title.alignment = .center
-        title.frame = NSRect(x: 0, y: 210, width: 460, height: 24)
+        title.frame = NSRect(x: 0, y: 250, width: 460, height: 24)
         title.autoresizingMask = [.width]
         content.addSubview(title)
 
@@ -40,7 +40,7 @@ class ErrorWindowController: NSWindowController {
         urlLabel.font = NSFont.systemFont(ofSize: 12)
         urlLabel.textColor = .secondaryLabelColor
         urlLabel.alignment = .center
-        urlLabel.frame = NSRect(x: 0, y: 186, width: 460, height: 18)
+        urlLabel.frame = NSRect(x: 0, y: 226, width: 460, height: 18)
         urlLabel.autoresizingMask = [.width]
         content.addSubview(urlLabel)
 
@@ -51,9 +51,27 @@ class ErrorWindowController: NSWindowController {
         desc.font = NSFont.systemFont(ofSize: 12)
         desc.textColor = .secondaryLabelColor
         desc.alignment = .center
-        desc.frame = NSRect(x: 40, y: 100, width: 380, height: 72)
+        desc.frame = NSRect(x: 40, y: 140, width: 380, height: 72)
         desc.autoresizingMask = [.width]
         content.addSubview(desc)
+
+        // "Don't have it yet?" link — only shown in direct mode for new users
+        if mode == "direct" {
+            let getLabel = NSTextField(labelWithString: "Don't have it yet?")
+            getLabel.font = NSFont.systemFont(ofSize: 12)
+            getLabel.textColor = .secondaryLabelColor
+            getLabel.alignment = .center
+            getLabel.frame = NSRect(x: 40, y: 110, width: 180, height: 18)
+            content.addSubview(getLabel)
+
+            let getBtn = NSButton(title: "github.com/nesquena/hermes-webui", target: self, action: #selector(openRepoURL))
+            getBtn.bezelStyle = .inline
+            getBtn.isBordered = false
+            getBtn.contentTintColor = NSColor.linkColor
+            getBtn.font = NSFont.systemFont(ofSize: 12)
+            getBtn.frame = NSRect(x: 220, y: 108, width: 210, height: 20)
+            content.addSubview(getBtn)
+        }
 
         let retryBtn = NSButton(title: "Try Again", target: self, action: #selector(retryTapped))
         retryBtn.bezelStyle = .rounded
@@ -72,4 +90,10 @@ class ErrorWindowController: NSWindowController {
 
     @objc private func retryTapped() { onRetry?() }
     @objc private func prefsTapped() { onOpenPreferences?() }
+
+    @objc private func openRepoURL() {
+        if let url = URL(string: "https://github.com/nesquena/hermes-webui") {
+            NSWorkspace.shared.open(url)
+        }
+    }
 }

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import ServiceManagement
 
 class PreferencesWindowController: NSWindowController {
 
@@ -12,10 +13,11 @@ class PreferencesWindowController: NSWindowController {
     private var remotePortField: NSTextField!
     private var targetURLField: NSTextField!
     private var testResultLabel: NSTextField!
+    private var launchAtLoginCheckbox: NSButton!
 
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 480),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 520),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -30,7 +32,7 @@ class PreferencesWindowController: NSWindowController {
 
     private func buildUI() {
         let content = window!.contentView!
-        var y: CGFloat = 420
+        var y: CGFloat = 460
 
         func sectionHeader(_ text: String) -> NSTextField {
             let label = NSTextField(labelWithString: text)
@@ -127,6 +129,27 @@ class PreferencesWindowController: NSWindowController {
         targetURLField = row(
             "Target URL", placeholder: "http://localhost:8787", defaultsKey: "targetURL")
 
+        // Launch at Login (fix #3) — uses SMAppService (macOS 13+)
+        launchAtLoginCheckbox = NSButton(
+            checkboxWithTitle: "Launch at login",
+            target: self,
+            action: #selector(toggleLaunchAtLogin(_:)))
+        launchAtLoginCheckbox.frame = NSRect(x: 164, y: y, width: 260, height: 22)
+        content.addSubview(launchAtLoginCheckbox)
+
+        if #available(macOS 13.0, *) {
+            launchAtLoginCheckbox.state =
+                SMAppService.mainApp.status == .enabled ? .on : .off
+        } else {
+            launchAtLoginCheckbox.isEnabled = false
+            let note = NSTextField(labelWithString: "Requires macOS 13 or later")
+            note.font = NSFont.systemFont(ofSize: 11)
+            note.textColor = .secondaryLabelColor
+            note.frame = NSRect(x: 294, y: y, width: 180, height: 22)
+            content.addSubview(note)
+        }
+        y -= 36
+
         // Buttons
         let cancelBtn = NSButton(title: "Cancel", target: self, action: #selector(cancel))
         cancelBtn.bezelStyle = .rounded
@@ -150,6 +173,40 @@ class PreferencesWindowController: NSWindowController {
         testResultLabel.frame = NSRect(x: 164, y: 22, width: 90, height: 16)
         content.addSubview(testResultLabel)
     }
+
+    // MARK: - Launch at login (fix #3)
+
+    @objc func toggleLaunchAtLogin(_ sender: NSButton) {
+        guard #available(macOS 13.0, *) else { return }
+        let service = SMAppService.mainApp
+        let wantEnabled = sender.state == .on
+        Task { @MainActor in
+            do {
+                if wantEnabled {
+                    if service.status != .enabled { try service.register() }
+                } else {
+                    if service.status == .enabled { try await service.unregister() }
+                }
+                // Re-sync UI to authoritative status (handles .requiresApproval)
+                sender.state = (service.status == .enabled) ? .on : .off
+                if service.status == .requiresApproval {
+                    let alert = NSAlert()
+                    alert.messageText = "Approval required"
+                    alert.informativeText =
+                        "Enable Hermes in System Settings → General → Login Items."
+                    alert.runModal()
+                }
+            } catch {
+                sender.state = (service.status == .enabled) ? .on : .off
+                let alert = NSAlert()
+                alert.messageText = "Couldn't update Launch at Login"
+                alert.informativeText = error.localizedDescription
+                alert.runModal()
+            }
+        }
+    }
+
+    // MARK: - Save
 
     @objc func save() {
         let connectionMode = connectionModeSegment.selectedSegment == 0 ? "direct" : "ssh"

--- a/build.sh
+++ b/build.sh
@@ -85,6 +85,13 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
     <string>Hermes Agent uses the microphone for voice input in the chat interface.</string>
     <key>NSUserNotificationUsageDescription</key>
     <string>Hermes Agent notifies you when an AI response is ready while the window is in the background.</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+        <key>NSAllowsArbitraryLoadsInWebContent</key>
+        <true/>
+    </dict>
     <key>SUPublicEDKey</key>
     <string>daAlTqdBbYPSCDjS9IfTCJOFDo1jqtjMRZluhtAbKMY=</string>
     <key>SUFeedURL</key>


### PR DESCRIPTION
## v1.1.0 sprint — 6 quality-of-life fixes + 1 new feature

This PR addresses the most user-facing pain points from the issue backlog. All changes are self-contained — no new dependencies, no Info.plist key changes that require Entitlements.plist parity, no architectural changes.

---

### Fixed

**#27 — Error screen now links to the backend repo**
First-time users who hit "Cannot connect" had no way to find the backend. The path `~/hermes-webui-public` is un-Googleable. Added a clickable `github.com/nesquena/hermes-webui` link (direct mode only — SSH users already know the repo).

**#23 — Dark mode white flash on startup (FOUC)**
WKWebView rendered white before the dark theme loaded. Two-layer fix: `underPageBackgroundColor = .windowBackgroundColor` (macOS 12+) sets the native backing color before the first paint; a `documentStart` userScript sets the HTML `background` for the brief window before CSS loads.

**#25 — Non-localhost URLs silently failing (ATS)**
`http://` to Tailscale IPs, LAN addresses, or custom hostnames was blocked by WKWebView's App Transport Security with no visible error. Added `NSAllowsArbitraryLoadsInWebContent = true` to Info.plist in both `build.sh` and the CI workflow (parity maintained). `NSAllowsArbitraryLoads` stays `false` so URLSession (used for preflight HTTP checks) keeps its ATS restrictions.

---

### Added

**#24 — Cmd+/Cmd− zoom keyboard shortcuts**
Pinch-to-zoom was already enabled (`allowsMagnification = true`). This adds a View menu with Zoom In (`⌘+`), Zoom Out (`⌘-`), and Actual Size (`⌘0`) that call `webView.magnification`. The implementation routes through a `webViewForZoom` accessor on `BrowserWindowController` to avoid making the private `webView` ivar public.

**#29 — Connection status indicator in window title**
Direct mode showed no feedback once connected — no indication of which backend URL was active or whether it was healthy. The window title now shows `Hermes Agent  ● localhost:8787` (filled dot = healthy, hollow = offline). A Timer polls `/health` every 30s and updates the title only when status changes. The timer is cancelled in `windowWillClose`.

**#3 — Launch at login**
Preferences → APP now includes a "Launch at login" checkbox. Implementation:
- macOS 13+: `SMAppService.mainApp.register()` / `await .unregister()`
- macOS 12: checkbox renders disabled with an inline "Requires macOS 13" note
- `.requiresApproval` state surfaces a nudge to System Settings → General → Login Items
- No entitlement or Info.plist change needed (SMAppService.mainApp works for non-sandboxed Developer ID apps)
- No UserDefaults mirroring — `SMAppService.mainApp.status` is the single source of truth

---

### Build note for Mac agent review

Swift cannot run on the Linux server. **Before merging, please ask Nathan to run on the Mac agent:**

```
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout sprint-v1-1-0 && git pull

swift package resolve
swift build -c release
swift test
bash build.sh

# Verify Info.plist has ATS keys:
/usr/libexec/PlistBuddy -c "Print :NSAppTransportSecurity" "Hermes Agent.app/Contents/Info.plist"

# Verify Sparkle keys still present:
/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

Expected: `swift build` succeeds, `swift test` passes, `bash build.sh` produces `Hermes Agent.app`.

Closes #27
Closes #23
Closes #25
Closes #24
Closes #29
Closes #3
