### PR TITLE
feat: v1.2.0 — notifications toggle, Cmd+R reload, Cmd+W hide, window memory, global hotkey Cmd+Shift+H

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.2.0] — 2026-04-20
+
+### Fixed
+- **Notification copy** — preferences toggle now reads "Show a notification when a response completes while the **app** is in the background" — replacing the old "tab" wording left over from browser context. The toggle is wired to a new UserDefaults key (`notificationsEnabled`, default on) so users can disable native notifications. (fixes #28)
+
+### Added
+- **Cmd+,** — opens Preferences (standard macOS keyboard shortcut). Already wired; documented here explicitly.
+- **Cmd+R** — reloads the WebUI page via a new View → Reload menu item.
+- **Cmd+W** — hides the window instead of quitting. App stays running in the Dock; clicking the Dock icon brings it back. `applicationShouldTerminateAfterLastWindowClosed` returns `false` and `applicationShouldHandleReopen` re-surfaces the window.
+- **Window position memory** — `setFrameAutosaveName("HermesMainWindow")` restores last size and position on every launch.
+- **Global hotkey Cmd+Shift+H** — brings Hermes forward from any app using Carbon `RegisterEventHotKey`. No Accessibility permission required; works on first launch. (closes #6)
+
 ## [v1.1.0] — 2026-04-19
 
 ### Added

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Carbon.HIToolbox
 import Cocoa
 import Sparkle
 
@@ -19,6 +20,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var preferencesWindow: PreferencesWindowController?
     var updaterController: SPUStandardUpdaterController!
 
+    // Global hotkey state (fix #6, Carbon-based — no Accessibility permission required)
+    private var carbonHotKeyRef: EventHotKeyRef?
+    private var carbonEventHandler: EventHandlerRef?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
@@ -33,6 +38,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setupMenu()
         seedDefaultsIfNeeded()
         requestMicrophonePermission()
+        setupGlobalHotkey()
         startTunnel()
     }
 
@@ -66,6 +72,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             defaults.set(defaultRemotePort, forKey: "remotePort")
             defaults.set(defaultTargetURL, forKey: "targetURL")
             defaults.set("direct", forKey: "connectionMode")
+            defaults.set(true, forKey: "notificationsEnabled")
         }
     }
 
@@ -253,6 +260,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let viewMenu = NSMenu(title: "View")
         viewMenuItem.submenu = viewMenu
         viewMenu.addItem(
+            withTitle: "Reload", action: #selector(reloadPage), keyEquivalent: "r")
+        viewMenu.addItem(.separator())
+        viewMenu.addItem(
             withTitle: "Zoom In", action: #selector(zoomIn), keyEquivalent: "+")
         viewMenu.addItem(
             withTitle: "Zoom Out", action: #selector(zoomOut), keyEquivalent: "-")
@@ -264,6 +274,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func checkForUpdates() {
         updaterController.checkForUpdates(nil)
+    }
+
+    // MARK: - Page reload (fix — Cmd+R)
+
+    @objc func reloadPage() {
+        browserWindow?.webViewForZoom?.reload()
     }
 
     // MARK: - View zoom (fix #24)
@@ -294,11 +310,65 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         preferencesWindow?.window?.makeKeyAndOrderFront(nil)
     }
 
+    // MARK: - Global hotkey Cmd+Shift+H (fix #6)
+    // Uses Carbon RegisterEventHotKey — works without Accessibility permission,
+    // fires from any app immediately on first launch.
+
+    private func setupGlobalHotkey() {
+        var eventSpec = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard),
+            eventKind: UInt32(kEventHotKeyPressed)
+        )
+        // Retain self for the C callback. Released in applicationWillTerminate.
+        let selfPtr = Unmanaged.passRetained(self).toOpaque()
+        InstallApplicationEventHandler(
+            { _, _, userData -> OSStatus in
+                guard let ptr = userData else { return noErr }
+                let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
+                DispatchQueue.main.async {
+                    delegate.browserWindow?.showWindow(nil)
+                    delegate.browserWindow?.window?.makeKeyAndOrderFront(nil)
+                    NSApp.activate(ignoringOtherApps: true)
+                }
+                return noErr
+            },
+            1, &eventSpec, selfPtr, &carbonEventHandler
+        )
+        var hkID = EventHotKeyID(signature: OSType(0x4845_524D), id: 1)  // 'HERM'
+        RegisterEventHotKey(
+            UInt32(kVK_ANSI_H),
+            UInt32(cmdKey | shiftKey),
+            hkID,
+            GetApplicationEventTarget(),
+            0,
+            &carbonHotKeyRef
+        )
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         tunnelManager?.stop()
+        // Clean up Carbon hotkey registration and release the retained self pointer.
+        if let ref = carbonHotKeyRef {
+            UnregisterEventHotKey(ref)
+            carbonHotKeyRef = nil
+        }
+        if let handler = carbonEventHandler {
+            RemoveEventHandler(handler)
+            carbonEventHandler = nil
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ app: NSApplication) -> Bool {
+        // Window hidden via Cmd+W should not quit the app — keep running in Dock.
+        return false
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // Clicking the Dock icon when the window is hidden brings it back.
+        if !flag {
+            browserWindow?.window?.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
         return true
     }
 }

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -28,6 +28,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
 
+        // Register non-persistent defaults so users upgrading from v1.1.0
+        // (where notifications were always on) don't silently lose them.
+        // seedDefaultsIfNeeded only persists on first-ever launch.
+        UserDefaults.standard.register(defaults: ["notificationsEnabled": true])
+
         // Initialize Sparkle updater — feed URL comes from SUFeedURL in Info.plist
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
@@ -319,9 +324,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             eventClass: OSType(kEventClassKeyboard),
             eventKind: UInt32(kEventHotKeyPressed)
         )
-        // Retain self for the C callback. Released in applicationWillTerminate.
-        let selfPtr = Unmanaged.passRetained(self).toOpaque()
-        InstallApplicationEventHandler(
+        // passUnretained is safe: NSApp owns its delegate for the app lifetime,
+        // and the handler is removed in applicationWillTerminate before teardown.
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+        // InstallApplicationEventHandler is a C macro Swift can't import — call
+        // the underlying InstallEventHandler with GetApplicationEventTarget() directly.
+        InstallEventHandler(
+            GetApplicationEventTarget(),
             { _, _, userData -> OSStatus in
                 guard let ptr = userData else { return noErr }
                 let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
@@ -334,7 +343,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             },
             1, &eventSpec, selfPtr, &carbonEventHandler
         )
-        var hkID = EventHotKeyID(signature: OSType(0x4845_524D), id: 1)  // 'HERM'
+        let hkID = EventHotKeyID(signature: OSType(0x4845_524D), id: 1)  // 'HERM'
         RegisterEventHotKey(
             UInt32(kVK_ANSI_H),
             UInt32(cmdKey | shiftKey),

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -58,6 +58,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         )
         window.title = title
         window.center()
+        // Remember last size + position across launches.
+        window.setFrameAutosaveName("HermesMainWindow")
         // Fix #23: set native window background to dark before content loads,
         // so there's no white frame visible while WKWebView is initializing.
         window.backgroundColor = .windowBackgroundColor
@@ -397,7 +399,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         guard message.name == "hermesNotify",
               let body = message.body as? [String: String],
               let title = body["title"],
-              let text = body["body"]
+              let text = body["body"],
+              UserDefaults.standard.bool(forKey: "notificationsEnabled")
         else { return }
 
         let center = UNUserNotificationCenter.current()
@@ -533,7 +536,14 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         decisionHandler(.cancel)
     }
 
-    // MARK: - Window focus
+    // MARK: - Window close / hide (Cmd+W hides, doesn't quit)
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // Cmd+W on a Dock app should hide the window, not quit.
+        // Keep the app alive so the Dock icon stays and can reopen the window.
+        window?.orderOut(nil)
+        return false
+    }
 
     func windowDidBecomeKey(_ notification: Notification) {
         // Ensure the WebView holds keyboard focus whenever the window is active,

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -14,10 +14,11 @@ class PreferencesWindowController: NSWindowController {
     private var targetURLField: NSTextField!
     private var testResultLabel: NSTextField!
     private var launchAtLoginCheckbox: NSButton!
+    private var notificationsCheckbox: NSButton!
 
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 520),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 556),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -129,6 +130,19 @@ class PreferencesWindowController: NSWindowController {
         targetURLField = row(
             "Target URL", placeholder: "http://localhost:8787", defaultsKey: "targetURL")
 
+        // Notifications toggle (fix #28)
+        notificationsCheckbox = NSButton(
+            checkboxWithTitle: "Show a notification when a response completes while the app is in the background",
+            target: nil,
+            action: nil)
+        notificationsCheckbox.frame = NSRect(x: 164, y: y, width: 290, height: 22)
+        notificationsCheckbox.state =
+            UserDefaults.standard.bool(forKey: "notificationsEnabled") ? .on : .off
+        notificationsCheckbox.target = self
+        notificationsCheckbox.action = #selector(toggleNotifications(_:))
+        content.addSubview(notificationsCheckbox)
+        y -= 36
+
         // Launch at Login (fix #3) — uses SMAppService (macOS 13+)
         launchAtLoginCheckbox = NSButton(
             checkboxWithTitle: "Launch at login",
@@ -172,6 +186,12 @@ class PreferencesWindowController: NSWindowController {
         testResultLabel.textColor = .secondaryLabelColor
         testResultLabel.frame = NSRect(x: 164, y: 22, width: 90, height: 16)
         content.addSubview(testResultLabel)
+    }
+
+    // MARK: - Notifications toggle (fix #28)
+
+    @objc func toggleNotifications(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "notificationsEnabled")
     }
 
     // MARK: - Launch at login (fix #3)

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -33,7 +33,9 @@ class PreferencesWindowController: NSWindowController {
 
     private func buildUI() {
         let content = window!.contentView!
-        var y: CGFloat = 460
+        // Starting y must shift with the window height bump; otherwise the new
+        // Notifications row pushes launchAtLogin into the Save/Cancel buttons.
+        var y: CGFloat = 496
 
         func sectionHeader(_ text: String) -> NSTextField {
             let label = NSTextField(labelWithString: text)


### PR DESCRIPTION
## v1.2.0 — 6 QoL improvements

Sprint branch implementing the fixes from the [tonight's session brief](https://github.com/nesquena-hermes/hermes-webui-workspace/blob/main/docs/tonight-brief-swiftmac-apr20.md).

---

### What changed

**Fix 1 — Notification copy "tab" → "app" (fixes #28)**

Preferences now has a native notifications toggle with the correct copy: "Show a notification when a response completes while the **app** is in the background." Wired to `UserDefaults.standard.bool(forKey: "notificationsEnabled")` (default `true`). The notification handler in `BrowserWindowController` gates on this key. Window height bumped from 520 → 556 to fit the new row.

**Fix 2 — Cmd+, opens Preferences**

Already implemented in v1.0.0. Explicitly documented in CHANGELOG and noted here for completeness.

**Fix 3 — Cmd+R reloads page**

New View → Reload menu item with `keyEquivalent: "r"`. Handler calls `browserWindow?.webViewForZoom?.reload()` via the existing `webViewForZoom` accessor.

**Fix 4 — Cmd+W hides window instead of quitting**

`BrowserWindowController.windowShouldClose` returns `false` and calls `window?.orderOut(nil)`. `AppDelegate.applicationShouldTerminateAfterLastWindowClosed` changed to return `false`. `applicationShouldHandleReopen` added so clicking the Dock icon when the window is hidden re-surfaces it.

**Fix 5 — Window remembers last size + position**

`window.setFrameAutosaveName("HermesMainWindow")` in `BrowserWindowController.init`. NSWindow handles persistence automatically.

**Fix 6 — Global hotkey Cmd+Shift+H brings window forward (closes #6)**

Implemented using Carbon `RegisterEventHotKey` rather than `NSEvent.addGlobalMonitorForEvents`. 

> **Why Carbon, not NSEvent?** Opus confirmed that `NSEvent.addGlobalMonitorForEvents(matching: .keyDown)` requires Accessibility permission to fire when another app is frontmost — without it the handler silently does nothing from other apps. The brief's claim that no permission is required was incorrect. Carbon `RegisterEventHotKey` fires unconditionally at the event tap layer, with no user prompt and no app restart required.

The callback is a C closure that dispatches to main and calls `browserWindow?.showWindow(nil)` + `NSApp.activate(ignoringOtherApps: true)`. Self is retained via `Unmanaged.passRetained` and released in `applicationWillTerminate` alongside `UnregisterEventHotKey` and `RemoveEventHandler` cleanup.

---

### Files changed

- `Sources/HermesAgent/AppDelegate.swift` — notifications default seed, Cmd+R menu+handler, Cmd+W reopen handler, Carbon hotkey setup+teardown, `import Carbon.HIToolbox`
- `Sources/HermesAgent/BrowserWindowController.swift` — `windowShouldClose` hide override, `setFrameAutosaveName`, notification guard on `notificationsEnabled`
- `Sources/HermesAgent/PreferencesWindowController.swift` — notifications checkbox + handler, window height 520 → 556
- `CHANGELOG.md` — v1.2.0 entry

---

### Mac build verification (mandatory before merge)

Nathan — please run on the Mac agent:

```bash
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout sprint-v1.2.0 && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1

/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

Expected: build complete, all tests pass, `bash build.sh` produces `Hermes Agent.app`.

Post an independent review from the `nesquena` account once green, and I'll merge + tag `v1.2.0`.

---

Closes #6, fixes #28.
