### PR TITLE
fix: v1.2.1 — hotkey OSStatus check, redundant default seed, checkbox init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.2.1] — 2026-04-20
+
+### Fixed
+- **RegisterEventHotKey OSStatus now checked** — if Cmd+Shift+H is already claimed by another app (Alfred, Raycast, etc.), a diagnostic `NSLog` fires instead of silently no-opping. Surfaced by the v1.2.0 independent review.
+- **Redundant `notificationsEnabled` seed removed** — `seedDefaultsIfNeeded()` was setting `notificationsEnabled` alongside `UserDefaults.standard.register(defaults:)`, which already covers both fresh installs and upgrades. The seed in `register(defaults:)` is the authoritative one; the duplicate in `seedDefaultsIfNeeded` is removed.
+- **Notifications checkbox init cleaned up** — `target` and `action` are now set in the `NSButton` initializer directly, removing the redundant two-line post-init reassignment.
+
 ## [v1.2.0] — 2026-04-20
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -77,7 +77,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             defaults.set(defaultRemotePort, forKey: "remotePort")
             defaults.set(defaultTargetURL, forKey: "targetURL")
             defaults.set("direct", forKey: "connectionMode")
-            defaults.set(true, forKey: "notificationsEnabled")
         }
     }
 
@@ -344,7 +343,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             1, &eventSpec, selfPtr, &carbonEventHandler
         )
         let hkID = EventHotKeyID(signature: OSType(0x4845_524D), id: 1)  // 'HERM'
-        RegisterEventHotKey(
+        let status = RegisterEventHotKey(
             UInt32(kVK_ANSI_H),
             UInt32(cmdKey | shiftKey),
             hkID,
@@ -352,6 +351,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             0,
             &carbonHotKeyRef
         )
+        if status != noErr {
+            NSLog("[HermesAgent] RegisterEventHotKey failed (OSStatus %d) — Cmd+Shift+H may already be claimed by another app.", status)
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -135,13 +135,11 @@ class PreferencesWindowController: NSWindowController {
         // Notifications toggle (fix #28)
         notificationsCheckbox = NSButton(
             checkboxWithTitle: "Show a notification when a response completes while the app is in the background",
-            target: nil,
-            action: nil)
+            target: self,
+            action: #selector(toggleNotifications(_:)))
         notificationsCheckbox.frame = NSRect(x: 164, y: y, width: 290, height: 22)
         notificationsCheckbox.state =
             UserDefaults.standard.bool(forKey: "notificationsEnabled") ? .on : .off
-        notificationsCheckbox.target = self
-        notificationsCheckbox.action = #selector(toggleNotifications(_:))
         content.addSubview(notificationsCheckbox)
         y -= 36
 


### PR DESCRIPTION
## v1.2.1 — three nits from the v1.2.0 review

All three items raised or implied by the v1.2.0 independent review. No behavior changes for users — the only observable difference is a diagnostic log line if Cmd+Shift+H conflicts.

---

### Changes

**1. RegisterEventHotKey OSStatus checked (reviewer's explicit note)**

```swift
// before
RegisterEventHotKey(UInt32(kVK_ANSI_H), UInt32(cmdKey | shiftKey), hkID,
    GetApplicationEventTarget(), 0, &carbonHotKeyRef)

// after
let status = RegisterEventHotKey(...)
if status != noErr {
    NSLog("[HermesAgent] RegisterEventHotKey failed (OSStatus %d) — Cmd+Shift+H may already be claimed by another app.", status)
}
```

**2. Redundant `notificationsEnabled` seed removed from `seedDefaultsIfNeeded`**

`UserDefaults.standard.register(defaults: ["notificationsEnabled": true])` in `applicationDidFinishLaunching` covers both fresh installs and upgrades. The duplicate `defaults.set(true, forKey: "notificationsEnabled")` inside `seedDefaultsIfNeeded` (which only runs on first launch) was redundant and slightly confusing. Removed.

**3. Notifications checkbox `target`/`action` set in initializer**

```swift
// before: init with nil then immediately reassign
notificationsCheckbox = NSButton(checkboxWithTitle: "...", target: nil, action: nil)
notificationsCheckbox.target = self
notificationsCheckbox.action = #selector(toggleNotifications(_:))

// after: set once, correctly
notificationsCheckbox = NSButton(checkboxWithTitle: "...", target: self,
    action: #selector(toggleNotifications(_:)))
```

---

### Mac build verification

Nathan — same drill as v1.2.0:

```bash
cd /tmp/swift-mac-test
git fetch origin && git checkout sprint-v1.2.1 && git pull --rebase
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1
```

Post approve from `nesquena` and I'll merge + tag `v1.2.1`.
