### PR TITLE
fix: v1.2.2 — Preferences truncation fix + global hotkey discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [v1.2.2] — 2026-04-20
+
+### Fixed
+- **Preferences window truncation** — widened window from 480 to 520px. "Save & Reconnect" button width increased (100 → 140px) so the label no longer clips. Notification checkbox width increased (290 → 330px) to fit the full label. All section headers, dividers, and input fields scaled accordingly. (fixes #34)
+
+### Added
+- **Window → Show Hermes (⌘⇧H)** — menu item in the Window menu that mirrors the global hotkey, making it discoverable. Teaches the shortcut to users who scan menus. (fixes #35)
+- **Preferences: global shortcut label** — read-only "Global shortcut: ⌘⇧H — bring Hermes forward from any app" row in the APP section of Preferences. (fixes #35)
+- **README: Keyboard shortcuts table** — new section listing all six keyboard shortcuts including the global ⌘⇧H. (fixes #35)
+
 ## [v1.2.1] — 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ Settings persist across launches.
 
 ---
 
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| ⌘, | Open Preferences |
+| ⌘R | Reload the WebUI page |
+| ⌘W | Hide window (app keeps running in Dock) |
+| ⌘⇧H | Bring Hermes forward from any app (global) |
+| ⌘+ / ⌘− | Zoom in / zoom out |
+| ⌘0 | Reset zoom to actual size |
+
+The global shortcut ⌘⇧H works system-wide — press it from any app to snap Hermes back to the front.
+
+---
+
 ## SSH security
 
 - `StrictHostKeyChecking=accept-new` — on the first connection to a new host, the key is added to `~/.ssh/known_hosts` automatically. On all later connections, a changed host key is rejected, protecting against MITM attacks after the first connect.

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -255,6 +255,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let windowMenu = NSMenu(title: "Window")
         windowMenuItem.submenu = windowMenu
         windowMenu.addItem(
+            withTitle: "Show Hermes", action: #selector(showMainWindow), keyEquivalent: "H")
+        windowMenu.addItem(.separator())
+        windowMenu.addItem(
             withTitle: "Minimize", action: #selector(NSWindow.miniaturize(_:)), keyEquivalent: "m")
         windowMenu.addItem(
             withTitle: "Zoom", action: #selector(NSWindow.zoom(_:)), keyEquivalent: "")
@@ -278,6 +281,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func checkForUpdates() {
         updaterController.checkForUpdates(nil)
+    }
+
+    // MARK: - Show window (mirrors global hotkey Cmd+Shift+H, fix #35)
+
+    @objc func showMainWindow() {
+        browserWindow?.showWindow(nil)
+        browserWindow?.window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     // MARK: - Page reload (fix — Cmd+R)

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -18,7 +18,7 @@ class PreferencesWindowController: NSWindowController {
 
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 556),
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 592),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -35,20 +35,20 @@ class PreferencesWindowController: NSWindowController {
         let content = window!.contentView!
         // Starting y must shift with the window height bump; otherwise the new
         // Notifications row pushes launchAtLogin into the Save/Cancel buttons.
-        var y: CGFloat = 496
+        var y: CGFloat = 532
 
         func sectionHeader(_ text: String) -> NSTextField {
             let label = NSTextField(labelWithString: text)
             label.font = NSFont.systemFont(ofSize: 10, weight: .semibold)
             label.textColor = .secondaryLabelColor
-            label.frame = NSRect(x: 24, y: y, width: 420, height: 16)
+            label.frame = NSRect(x: 24, y: y, width: 460, height: 16)
             content.addSubview(label)
             y -= 28
             return label
         }
 
         func row(
-            _ labelText: String, placeholder: String, defaultsKey: String, width: CGFloat = 260,
+            _ labelText: String, placeholder: String, defaultsKey: String, width: CGFloat = 300,
             isSSH: Bool = false
         ) -> NSTextField {
             let label = NSTextField(labelWithString: labelText)
@@ -74,7 +74,7 @@ class PreferencesWindowController: NSWindowController {
         func divider() -> NSBox {
             let line = NSBox()
             line.boxType = .separator
-            line.frame = NSRect(x: 24, y: y + 10, width: 432, height: 1)
+            line.frame = NSRect(x: 24, y: y + 10, width: 472, height: 1)
             content.addSubview(line)
             y -= 20
             return line
@@ -91,7 +91,7 @@ class PreferencesWindowController: NSWindowController {
         connectionModeSegment = NSSegmentedControl(
             labels: ["Direct (Local)", "SSH Tunnel"], trackingMode: .selectOne, target: self,
             action: #selector(modeChanged))
-        connectionModeSegment.frame = NSRect(x: 164, y: y - 2, width: 260, height: 22)
+        connectionModeSegment.frame = NSRect(x: 164, y: y - 2, width: 300, height: 22)
         let mode = UserDefaults.standard.string(forKey: "connectionMode") ?? "direct"
         connectionModeSegment.selectedSegment = mode == "ssh" ? 1 : 0
         content.addSubview(connectionModeSegment)
@@ -132,12 +132,25 @@ class PreferencesWindowController: NSWindowController {
         targetURLField = row(
             "Target URL", placeholder: "http://localhost:8787", defaultsKey: "targetURL")
 
+        // Global shortcut hint (fix #35)
+        let shortcutLabel = NSTextField(labelWithString: "Global shortcut:")
+        shortcutLabel.font = NSFont.systemFont(ofSize: 13)
+        shortcutLabel.frame = NSRect(x: 24, y: y, width: 130, height: 22)
+        shortcutLabel.alignment = .right
+        content.addSubview(shortcutLabel)
+        let shortcutValue = NSTextField(labelWithString: "⌘⇧H — bring Hermes forward from any app")
+        shortcutValue.font = NSFont.systemFont(ofSize: 13)
+        shortcutValue.textColor = .secondaryLabelColor
+        shortcutValue.frame = NSRect(x: 164, y: y, width: 330, height: 22)
+        content.addSubview(shortcutValue)
+        y -= 36
+
         // Notifications toggle (fix #28)
         notificationsCheckbox = NSButton(
             checkboxWithTitle: "Show a notification when a response completes while the app is in the background",
             target: self,
             action: #selector(toggleNotifications(_:)))
-        notificationsCheckbox.frame = NSRect(x: 164, y: y, width: 290, height: 22)
+        notificationsCheckbox.frame = NSRect(x: 164, y: y, width: 330, height: 22)
         notificationsCheckbox.state =
             UserDefaults.standard.bool(forKey: "notificationsEnabled") ? .on : .off
         content.addSubview(notificationsCheckbox)
@@ -148,7 +161,7 @@ class PreferencesWindowController: NSWindowController {
             checkboxWithTitle: "Launch at login",
             target: self,
             action: #selector(toggleLaunchAtLogin(_:)))
-        launchAtLoginCheckbox.frame = NSRect(x: 164, y: y, width: 260, height: 22)
+        launchAtLoginCheckbox.frame = NSRect(x: 164, y: y, width: 300, height: 22)
         content.addSubview(launchAtLoginCheckbox)
 
         if #available(macOS 13.0, *) {
@@ -159,7 +172,7 @@ class PreferencesWindowController: NSWindowController {
             let note = NSTextField(labelWithString: "Requires macOS 13 or later")
             note.font = NSFont.systemFont(ofSize: 11)
             note.textColor = .secondaryLabelColor
-            note.frame = NSRect(x: 294, y: y, width: 180, height: 22)
+            note.frame = NSRect(x: 294, y: y, width: 210, height: 22)
             content.addSubview(note)
         }
         y -= 36
@@ -167,13 +180,13 @@ class PreferencesWindowController: NSWindowController {
         // Buttons
         let cancelBtn = NSButton(title: "Cancel", target: self, action: #selector(cancel))
         cancelBtn.bezelStyle = .rounded
-        cancelBtn.frame = NSRect(x: 264, y: 16, width: 90, height: 32)
+        cancelBtn.frame = NSRect(x: 254, y: 16, width: 90, height: 32)
         content.addSubview(cancelBtn)
 
         let saveBtn = NSButton(title: "Save & Reconnect", target: self, action: #selector(save))
         saveBtn.bezelStyle = .rounded
         saveBtn.keyEquivalent = "\r"
-        saveBtn.frame = NSRect(x: 362, y: 16, width: 100, height: 32)
+        saveBtn.frame = NSRect(x: 356, y: 16, width: 140, height: 32)
         content.addSubview(saveBtn)
 
         let testBtn = NSButton(title: "Test Connection", target: self, action: #selector(testConnection))


### PR DESCRIPTION
## v1.2.2 — Preferences truncation fix + hotkey discoverability

Closes #34, closes #35.

---

### Fix #34 — Preferences window truncation

Two elements were cut off in the Preferences window:

- "Save & Reconnect" button rendered as "Save & Re…" — button frame was only 100px wide
- Notification checkbox label clipped mid-sentence — frame was only 290px wide

**Changes:**
- Window widened 480 → 520px
- Starting layout `y` bumped from 496 → 532 to match the taller window
- Save button: x=362 w=100 → x=356 w=140 (fits "Save & Reconnect" with room to spare)
- Cancel button: x=264 → x=254 (maintains gap between buttons)
- Notifications checkbox: w=290 → w=330
- Launch at login checkbox: w=260 → w=300
- Section header width: 420 → 460
- Divider width: 432 → 472
- Default text field width: 260 → 300
- Segmented control width: 260 → 300
- "Requires macOS 13" note: w=180 → w=210

### Fix #35 — Global hotkey ⌘⇧H is undiscoverable

Three surfaces updated:

**1. Window menu item "Show Hermes ⌘⇧H"**
New `showMainWindow()` action added to AppDelegate. Menu item uses `keyEquivalent: "H"` (uppercase = macOS auto-applies Shift modifier, shows as ⌘⇧H in the menu). This teaches the shortcut to any user who scans the menu bar — the standard macOS pattern for surfacing shortcuts.

**2. Preferences APP section — read-only shortcut label**
Row reading "Global shortcut: ⌘⇧H — bring Hermes forward from any app" added below Target URL. Preferences window height bumped 556 → 592 to accommodate it.

**3. README — Keyboard shortcuts table**
New "## Keyboard shortcuts" section with a six-row table covering all shortcuts added to README between Configuration and SSH security.

---

### Mac build verification

```bash
cd /tmp/swift-mac-test
git fetch origin && git checkout sprint-v1.2.2 && git pull --rebase
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1
```

Please post approval from `nesquena` on this PR when green. I'll merge and tag `v1.2.2`.
