### PR TITLE
feat: v1.3.0 — auto-reconnect, zoom+fullscreen persistence, Dock badge, open-in-browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v1.3.0] — 2026-04-20
+
+### Added
+- **Auto-reconnect on network restore (NWPathMonitor)** — when WiFi drops and comes back,
+  or a VPN connects, the app automatically re-attempts connection without any manual click.
+  Only fires when the app is already in an error or disconnected state; no action is taken
+  if the backend is simply down with a healthy network. Uses `Network.framework`
+  `NWPathMonitor`, no Accessibility permission required. (closes #38)
+- **Zoom level persistence** — zoom level (Cmd++/Cmd+-/Cmd+0) is now saved to UserDefaults
+  and restored after every page load, including reconnects. (part of closes #43)
+- **Full-screen state persistence** — if the app was in full-screen when quit, it returns to
+  full-screen on next launch. Uses `NSWindowDelegate` `windowDidEnterFullScreen`/
+  `windowDidExitFullScreen` callbacks. (part of closes #43)
+- **Dock icon badge when offline** — the Dock icon shows a "!" badge when the backend is
+  unreachable (direct mode health check failure or SSH tunnel disconnects). Clears
+  automatically when the connection is restored. Visible even when the window is hidden. (closes #39)
+- **View → Open in Browser** — opens the configured Hermes URL in the system default browser.
+  Useful for comparison or debugging without changing any settings.
+
 ## [v1.2.2] — 2026-04-20
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Carbon.HIToolbox
 import Cocoa
+import Network
 import Sparkle
 
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -24,6 +25,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var carbonHotKeyRef: EventHotKeyRef?
     private var carbonEventHandler: EventHandlerRef?
 
+    // NWPathMonitor auto-reconnect (fix #38)
+    private let pathMonitor = NWPathMonitor()
+    private let pathMonitorQueue = DispatchQueue(label: "hermes.network.monitor")
+    private var lastPathStatus: NWPath.Status = .satisfied
+    private var pendingReconnect: DispatchWorkItem?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
@@ -45,6 +52,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         requestMicrophonePermission()
         setupGlobalHotkey()
         startTunnel()
+        startPathMonitor()
     }
 
     private func requestMicrophonePermission() {
@@ -88,6 +96,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let splashSubtitle = connectionMode == "ssh" ? "Establishing SSH tunnel…" : "Connecting…"
         splashWindow = SplashWindowController(title: appTitle, subtitle: splashSubtitle)
         splashWindow.showWindow(nil)
+        browserWindow?.isIntentionalClose = true
         browserWindow?.close()
         browserWindow = nil
         errorWindow?.close()
@@ -172,9 +181,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         browser.showWindow(nil)
         browserWindow = browser
+
+        // Restore full-screen state (fix #43)
+        if UserDefaults.standard.bool(forKey: "windowWasFullScreen") {
+            DispatchQueue.main.async {
+                if browser.window?.styleMask.contains(.fullScreen) == false {
+                    browser.window?.toggleFullScreen(nil)
+                }
+            }
+        }
+
+        // Clear offline badge when connected (fix #39)
+        setOfflineBadge(false)
     }
 
     private func showErrorWindow(targetURL: String, mode: String) {
+        browserWindow?.isIntentionalClose = true
         browserWindow?.close()
         browserWindow = nil
         let err = ErrorWindowController(
@@ -193,6 +215,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         err.showWindow(nil)
         err.window?.makeKeyAndOrderFront(nil)
         errorWindow = err
+
+        // Show offline badge when in error state (fix #39)
+        setOfflineBadge(true)
     }
 
     /// Verify the target URL answers HTTP before opening the main browser.
@@ -211,6 +236,44 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         URLSession.shared.dataTask(with: request) { _, response, _ in
             completion(response is HTTPURLResponse)
         }.resume()
+    }
+
+    // MARK: - Dock badge (fix #39)
+
+    func setOfflineBadge(_ offline: Bool) {
+        DispatchQueue.main.async {
+            NSApp.dockTile.badgeLabel = offline ? "!" : nil
+        }
+    }
+
+    // MARK: - NWPathMonitor auto-reconnect (fix #38)
+
+    private func startPathMonitor() {
+        pathMonitor.pathUpdateHandler = { [weak self] path in
+            guard let self = self else { return }
+            DispatchQueue.main.async {
+                let previous = self.lastPathStatus
+                self.lastPathStatus = path.status
+                // Only react to unsatisfied → satisfied transitions.
+                guard previous != .satisfied, path.status == .satisfied else { return }
+                self.scheduleAutoReconnect()
+            }
+        }
+        pathMonitor.start(queue: pathMonitorQueue)
+    }
+
+    private func scheduleAutoReconnect() {
+        pendingReconnect?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            let inErrorState = self.errorWindow != nil
+                || self.tunnelManager?.status == .disconnected
+            guard inErrorState else { return }
+            NSLog("[HermesAgent] Network came back — auto-reconnecting")
+            self.startTunnel()
+        }
+        pendingReconnect = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
     }
 
     func setupMenu() {
@@ -249,7 +312,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
         editMenu.addItem(
             withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
-
         let windowMenuItem = NSMenuItem()
         menuBar.addItem(windowMenuItem)
         let windowMenu = NSMenu(title: "Window")
@@ -275,6 +337,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             withTitle: "Zoom Out", action: #selector(zoomOut), keyEquivalent: "-")
         viewMenu.addItem(
             withTitle: "Actual Size", action: #selector(zoomReset), keyEquivalent: "0")
+        viewMenu.addItem(.separator())
+        viewMenu.addItem(
+            withTitle: "Open in Browser", action: #selector(openInBrowser), keyEquivalent: "")
 
         NSApp.mainMenu = menuBar
     }
@@ -297,20 +362,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         browserWindow?.webViewForZoom?.reload()
     }
 
-    // MARK: - View zoom (fix #24)
+    // MARK: - Open in system browser (bonus feature)
+
+    @objc func openInBrowser() {
+        let urlString = UserDefaults.standard.string(forKey: "targetURL") ?? "http://localhost:8787"
+        if let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    // MARK: - View zoom (fix #24, #43 — zoom level persisted)
+
+    private static let zoomKey = "webViewMagnification"
 
     @objc func zoomIn() {
         guard let webView = browserWindow?.webViewForZoom else { return }
         webView.magnification = min(webView.magnification + 0.1, 3.0)
+        UserDefaults.standard.set(webView.magnification, forKey: Self.zoomKey)
     }
 
     @objc func zoomOut() {
         guard let webView = browserWindow?.webViewForZoom else { return }
         webView.magnification = max(webView.magnification - 0.1, 0.5)
+        UserDefaults.standard.set(webView.magnification, forKey: Self.zoomKey)
     }
 
     @objc func zoomReset() {
         browserWindow?.webViewForZoom?.magnification = 1.0
+        UserDefaults.standard.set(1.0, forKey: Self.zoomKey)
     }
 
     @objc func openPreferences() {
@@ -368,6 +447,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        pathMonitor.cancel()
+        pendingReconnect?.cancel()
         tunnelManager?.stop()
         // Clean up Carbon hotkey registration and release the retained self pointer.
         if let ref = carbonHotKeyRef {

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -39,6 +39,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private let connectionMode: String
     var onReconnect: (() -> Void)?
     var onNavigationFailed: (() -> Void)?
+    /// Set to true before programmatic close so windowDidExitFullScreen
+    /// doesn't clobber the saved full-screen preference (fix #43).
+    var isIntentionalClose = false
 
     // Health check timer for direct mode — polls /health every 30s and
     // reflects status in the window title (fix #29).
@@ -363,6 +366,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         }
         let dot = healthy ? "●" : "○"
         window?.title = "\(appTitle)  \(dot) \(hostDisplay)"
+        // Update Dock badge to reflect connection health (fix #39)
+        (NSApp.delegate as? AppDelegate)?.setOfflineBadge(!healthy)
     }
 
     func updateStatus(_ status: TunnelStatus, host: String, port: Int) {
@@ -378,10 +383,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                 self.statusDot.layer?.backgroundColor = NSColor.systemGreen.cgColor
                 self.statusLabel.stringValue = "Tunnel connected · \(host) · port \(port)"
                 self.reconnectButton.isHidden = true
+                (NSApp.delegate as? AppDelegate)?.setOfflineBadge(false)
             case .disconnected:
                 self.statusDot.layer?.backgroundColor = NSColor.systemRed.cgColor
                 self.statusLabel.stringValue = "Tunnel disconnected · click Reconnect to retry"
                 self.reconnectButton.isHidden = false
+                (NSApp.delegate as? AppDelegate)?.setOfflineBadge(true)
             }
         }
     }
@@ -429,6 +436,17 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                 self?.notificationAuthGranted = granted
                 if granted { postNotification() }
             }
+        }
+    }
+
+    // MARK: - Zoom level restore (fix #43)
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // Restore persisted zoom level. double(forKey:) returns 0.0 when unset —
+        // treat any value outside the valid zoom range as "no preference".
+        let saved = UserDefaults.standard.double(forKey: "webViewMagnification")
+        if saved >= 0.5 && saved <= 3.0 {
+            webView.magnification = saved
         }
     }
 
@@ -549,6 +567,18 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // Ensure the WebView holds keyboard focus whenever the window is active,
         // so shortcuts like Cmd+K reach JavaScript without requiring an extra click.
         webView.becomeFirstResponder()
+    }
+
+    // MARK: - Full-screen state persistence (fix #43)
+
+    func windowDidEnterFullScreen(_ notification: Notification) {
+        UserDefaults.standard.set(true, forKey: "windowWasFullScreen")
+    }
+
+    func windowDidExitFullScreen(_ notification: Notification) {
+        // Don't clobber the saved preference during a programmatic reconnect close.
+        guard !isIntentionalClose else { return }
+        UserDefaults.standard.set(false, forKey: "windowWasFullScreen")
     }
 
     func windowWillClose(_ notification: Notification) {


### PR DESCRIPTION
## v1.3.0 — Connection resilience, state persistence, Dock feedback

Five features that make the app feel more polished and reliable, all additive and targeted.

**Find in page (Cmd+F)** was originally included but removed after Opus pre-commit review caught that `WKFindInteraction`/`isFindInteractionEnabled` are iOS-only symbols — they don't exist on macOS and would break the CI build. Filed separately as #44 with the correct NSTextFinder approach for macOS.

---

### What's in this PR

**Auto-reconnect on network restore** (closes #38)
`NWPathMonitor` watches for `.unsatisfied → .satisfied` path transitions. When the network comes back and the app is currently in an error or disconnected state, it automatically calls `startTunnel()` after a 1s debounce. Lid close/open, WiFi switch, VPN connect — all handled without user action. No permissions required. The loop guard is tight: if the backend is simply down but the network is healthy, the path stays `.satisfied` and no extra triggers fire.

**Zoom level persistence** (part of closes #43)
Zoom in/out/reset now saves `webView.magnification` to UserDefaults (`webViewMagnification` key) on every change. `webView(_:didFinishNavigation:)` restores it. The `0.5–3.0` range check filters out the unset `0.0` sentinel and invalid values.

**Full-screen state persistence** (part of closes #43)
`windowDidEnterFullScreen`/`windowDidExitFullScreen` delegate callbacks save a `windowWasFullScreen` Bool to UserDefaults. On the next launch, `openBrowser()` calls `toggleFullScreen(nil)` in a single-tick `DispatchQueue.main.async` block after `showWindow()`. The `isIntentionalClose` flag on `BrowserWindowController` prevents `windowDidExitFullScreen` from clobbering the saved preference when `startTunnel()` programmatically closes the window during a reconnect.

**Dock icon badge when offline** (closes #39)
`AppDelegate.setOfflineBadge(_:)` sets `NSApp.dockTile.badgeLabel` to `"!"` when the backend is unreachable, `nil` to clear. Triggered from four places: `showErrorWindow`, `openBrowser`, `BrowserWindowController.updateWindowTitle` (direct-mode health check), and `updateStatus` (SSH mode `.connected`/`.disconnected`). All calls dispatch to main internally. Visible even when the window is hidden with Cmd+W.

**View → Open in Browser** (bonus)
Opens the configured Hermes URL in the system default browser. 5 lines, zero risk. Useful for debugging or comparing sessions without changing Preferences.

---

### Issues addressed

- Closes #38 (auto-reconnect)
- Closes #39 (Dock badge)
- Implements #43 (zoom + full-screen persistence — both halves)

### Not in this PR

- #37 (Find in page) — blocked: `WKFindInteraction` is iOS-only. Needs `NSTextFinder` or JS injection. Filed as #44.
- #41 (configurable hotkey) — standalone Preferences work, separate sprint
- #42 (multi-window) — architectural, not a one-session feature

---

### Mac agent build verification (mandatory before merge)

Please run the following on the Mac agent and report the result:

```
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout sprint-v1-3-0 && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1

/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

Expected: `swift build` green, all tests pass, `build.sh` produces `Hermes Agent.app`.

No new Info.plist keys, no new entitlements, no new frameworks beyond `Network` (auto-linked, no Package.swift changes needed).
