### PR TITLE
fix: v1.3.1 — shared zoomKey constant, NWPathMonitor comment, cast comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v1.3.1] — 2026-04-20
+
+### Fixed
+- **Shared zoom key constant** — `"webViewMagnification"` was defined as a private static
+  in `AppDelegate` and duplicated as a bare string literal in `BrowserWindowController`.
+  Made `AppDelegate.zoomKey` internal so `BrowserWindowController` references the single source
+  of truth. (reviewer follow-up from #44)
+- **NWPathMonitor reconnect scope documented** — added inline comment to `scheduleAutoReconnect`
+  clarifying that it fires on network-link events only, not backend-health events.
+- **`(NSApp.delegate as? AppDelegate)` cast comment** — acknowledged the intentional coupling
+  and why a full protocol abstraction isn't warranted here.
+
 ## [v1.3.0] — 2026-04-20
 
 ### Added

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -263,6 +263,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func scheduleAutoReconnect() {
+        // NOTE: This fires on network-link restoration (WiFi up, VPN connected, etc.),
+        // not on backend-health events. If the server is down but the network is healthy,
+        // no extra reconnect attempts fire — the path stays .satisfied so this is never called.
         pendingReconnect?.cancel()
         let work = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
@@ -373,7 +376,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - View zoom (fix #24, #43 — zoom level persisted)
 
-    private static let zoomKey = "webViewMagnification"
+    static let zoomKey = "webViewMagnification"
 
     @objc func zoomIn() {
         guard let webView = browserWindow?.webViewForZoom else { return }

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -366,7 +366,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         }
         let dot = healthy ? "●" : "○"
         window?.title = "\(appTitle)  \(dot) \(hostDisplay)"
-        // Update Dock badge to reflect connection health (fix #39)
+        // Update Dock badge. The cast is safe — AppDelegate is always the app delegate
+        // in this single-delegate architecture. A ConnectionStatusObserver protocol
+        // would decouple this but adds boilerplate not warranted for a utility method.
         (NSApp.delegate as? AppDelegate)?.setOfflineBadge(!healthy)
     }
 
@@ -444,7 +446,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         // Restore persisted zoom level. double(forKey:) returns 0.0 when unset —
         // treat any value outside the valid zoom range as "no preference".
-        let saved = UserDefaults.standard.double(forKey: "webViewMagnification")
+        let saved = UserDefaults.standard.double(forKey: AppDelegate.zoomKey)
         if saved >= 0.5 && saved <= 3.0 {
             webView.magnification = saved
         }


### PR DESCRIPTION
## v1.3.1 — Reviewer follow-up nits from #44

Three non-blocking items flagged in the #44 review, addressed as a same-session patch:

**Shared zoom key constant**
`"webViewMagnification"` was `private static let zoomKey` in `AppDelegate` and a bare string literal in `BrowserWindowController.didFinishNavigation`. Made `AppDelegate.zoomKey` internal; `BrowserWindowController` now references `AppDelegate.zoomKey` directly. Single source of truth, no magic string duplication.

**NWPathMonitor reconnect scope comment**
Added inline comment to `scheduleAutoReconnect()` documenting that the method fires on network-link events (WiFi up, VPN connected), not on backend-health events. Future readers won't need to trace the call chain to understand why a healthy-network / down-backend scenario doesn't loop.

**`(NSApp.delegate as? AppDelegate)` cast comment**
Added a brief comment acknowledging the intentional coupling and why a `ConnectionStatusObserver` protocol abstraction isn't warranted for this single-delegate app. Documents the design decision explicitly.

No behaviour change. No new APIs. Swift build and all 20 tests should still be green.

### Mac agent build verification

```
cd /tmp/swift-mac-test
git fetch origin && git checkout sprint-v1-3-1 && git pull --rebase
swift build -c release 2>&1
swift test 2>&1
```

Expected: same green result as #44.
