### PR TITLE
fix: v1.3.2 — mic permission no longer repeated, window size persists, nav failure guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v1.3.2] — 2026-04-20
+
+### Fixed
+- **Microphone permission prompt no longer appears on every launch** — removed the proactive
+  `requestMicrophonePermission()` call from `applicationDidFinishLaunching`. That call fired
+  on every launch and, once the user had denied mic access, showed an `NSAlert` on *every*
+  subsequent launch regardless of whether the mic was needed. The `WKUIDelegate` method
+  `requestMediaCapturePermissionFor` already handles mic grants correctly and lazily — the
+  OS prompt only appears the first time the user actually clicks the mic button in the web UI.
+  (user-reported)
+- **Window size now persists across launches** — for programmatically created `NSWindow`
+  instances, `setFrameAutosaveName` saves future frame changes but does not restore the
+  previously saved frame on re-creation. Added `setFrameUsingName("HermesMainWindow")`
+  immediately after the autosave call; `center()` now only runs on first launch (when no
+  saved frame exists). Last used size and position are preserved across restarts. (user-reported)
+- **Navigation failure double-fire guard** — both `didFailProvisionalNavigation` and the
+  5xx `decidePolicyFor navigationResponse` handler can fire on the same failing load event
+  during teardown. Added `didReportNavigationFailure` flag so the error window is only
+  opened once per navigation attempt.
+
 ## [v1.3.1] — 2026-04-20
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import Carbon.HIToolbox
 import Cocoa
 import Network
@@ -49,32 +48,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         setupMenu()
         seedDefaultsIfNeeded()
-        requestMicrophonePermission()
         setupGlobalHotkey()
         startTunnel()
         startPathMonitor()
     }
 
-    private func requestMicrophonePermission() {
-        switch AVCaptureDevice.authorizationStatus(for: .audio) {
-        case .notDetermined:
-            AVCaptureDevice.requestAccess(for: .audio) { _ in }
-        case .denied:
-            DispatchQueue.main.async {
-                let alert = NSAlert()
-                alert.messageText = "Microphone Access Required"
-                alert.informativeText = "Hermes Agent needs microphone access for voice input. Enable it in System Settings → Privacy & Security → Microphone."
-                alert.addButton(withTitle: "Open System Settings")
-                alert.addButton(withTitle: "Later")
-                if alert.runModal() == .alertFirstButtonReturn {
-                    NSWorkspace.shared.open(
-                        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!)
-                }
-            }
-        default:
-            break
-        }
-    }
 
     func seedDefaultsIfNeeded() {
         let defaults = UserDefaults.standard

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -39,6 +39,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private let connectionMode: String
     var onReconnect: (() -> Void)?
     var onNavigationFailed: (() -> Void)?
+    /// Guards against onNavigationFailed firing twice (both provisional and 5xx paths
+    /// can trigger on the same load event during teardown).
+    private var didReportNavigationFailure = false
     /// Set to true before programmatic close so windowDidExitFullScreen
     /// doesn't clobber the saved full-screen preference (fix #43).
     var isIntentionalClose = false
@@ -60,9 +63,15 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             defer: false
         )
         window.title = title
-        window.center()
-        // Remember last size + position across launches.
+        // Restore last window size + position (fix: window size resetting on launch).
+        // setFrameAutosaveName saves future changes but does NOT restore the saved frame —
+        // setFrameUsingName does the restore. For IB-created windows AppKit wires both;
+        // for code-created windows we must call both manually.
+        // setFrameUsingName returns false on first launch (no saved frame) — fall back to center().
         window.setFrameAutosaveName("HermesMainWindow")
+        if !window.setFrameUsingName("HermesMainWindow") {
+            window.center()
+        }
         // Fix #23: set native window background to dark before content loads,
         // so there's no white frame visible while WKWebView is initializing.
         window.backgroundColor = .windowBackgroundColor
@@ -467,6 +476,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
             return
         }
+        guard !didReportNavigationFailure else { return }
+        didReportNavigationFailure = true
         onNavigationFailed?()
     }
 
@@ -482,6 +493,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             httpResponse.statusCode >= 500
         {
             decisionHandler(.cancel)
+            guard !didReportNavigationFailure else { return }
+            didReportNavigationFailure = true
             onNavigationFailed?()
         } else {
             decisionHandler(.allow)


### PR DESCRIPTION
## v1.3.2 — Microphone permission fix, window size persistence, navigation guard

Three fixes, two user-reported.

---

### Fix 1 — Microphone permission prompt on every launch (user-reported)

**Root cause:** `requestMicrophonePermission()` was called unconditionally from `applicationDidFinishLaunching` on every launch. Once a user had denied mic access, this showed an `NSAlert` asking them to open System Settings on *every single launch*, even when the mic was never needed that session. The OS prompt also fired on every first-ever launch before the user had interacted with anything.

**Fix:** Deleted `requestMicrophonePermission()` entirely (21 lines) and removed its call from `applicationDidFinishLaunching`. Also removed the now-unused `import AVFoundation` from AppDelegate.

The `WKUIDelegate` method `requestMediaCapturePermissionFor` in `BrowserWindowController` already handles this correctly:
- On first mic use: asks the OS for permission, returns `.grant` or `.deny` based on the result
- On subsequent uses: if TCC is `.authorized`, returns `.grant` immediately — no prompt

The mic prompt will now only appear the first time the user actually clicks the mic button in the web UI. Once granted, it never prompts again.

### Fix 2 — Window size resets to 1280×830 on every launch (user-reported)

**Root cause:** `NSWindow.setFrameAutosaveName(_:)` saves frame changes to UserDefaults but does *not* restore a saved frame on window creation — that's `setFrameUsingName(_:)`. For windows created in Interface Builder, AppKit wires both automatically. For code-created windows (which this is), `setFrameUsingName` must be called explicitly.

**Fix:** Added `setFrameUsingName("HermesMainWindow")` immediately after `setFrameAutosaveName`. `center()` now only runs when `setFrameUsingName` returns `false` (first launch, no saved frame). Subsequent launches restore the exact last size and position.

```swift
// Before:
window.center()
window.setFrameAutosaveName("HermesMainWindow")

// After:
window.setFrameAutosaveName("HermesMainWindow")
if !window.setFrameUsingName("HermesMainWindow") {
    window.center()  // first launch only
}
```

### Fix 3 — Navigation failure double-fire guard

Both `didFailProvisionalNavigation` and the 5xx `decidePolicyFor navigationResponse` handler can fire on the same failing load event during teardown, opening the error window twice. Added `didReportNavigationFailure: Bool` flag; whichever handler fires first opens the error window, the second is a no-op.

---

### Issues / closes

- Fixes user-reported repeated microphone permission prompt
- Fixes user-reported window size reset on launch

---

### Mac agent build verification (required before merge)

```
cd /tmp/swift-mac-test
git fetch origin && git checkout sprint-v1-3-2 && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1

/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

No new Info.plist keys, no new entitlements, no new frameworks. `import AVFoundation` removed from AppDelegate (BrowserWindowController still imports it for `requestMediaCapturePermissionFor`).
