### PR TITLE
fix: v1.3.3 — mic denied recovery alert, window frame via NSWindowController autosave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v1.3.3] — 2026-04-20
+
+### Fixed
+- **Microphone "access denied" error after v1.3.2 upgrade** — v1.3.2 correctly removed the
+  aggressive launch-time mic prompt, but also inadvertently removed the recovery path for users
+  whose TCC permission was already `.denied`. Those users got silent failure with no way back.
+  Fixed: the `.denied` branch now calls `decisionHandler(.deny)` immediately (so WebKit doesn't
+  wait) and then shows a single "Open System Settings" alert pointing to Privacy & Security →
+  Microphone. Throttled to once per app session so it can't spam. (user-reported regression from v1.3.2)
+- **Window size still resetting to default after v1.3.2** — the v1.3.2 fix called
+  `setFrameAutosaveName` and `setFrameUsingName` on the raw `NSWindow` before `super.init`.
+  `NSWindowController` has its own `windowFrameAutosaveName` property that both saves and
+  restores the frame — when the controller initialises, its default empty value overwrote the
+  window-level setting, so subsequent resizes were never persisted. Fixed: removed the window-level
+  calls and set `self.windowFrameAutosaveName = "HermesMainWindow"` on the controller after
+  `super.init`. AppKit now manages save and restore atomically. `center()` is guarded to
+  first-launch only. (user-reported regression from v1.3.2)
+
 ## [v1.3.2] — 2026-04-20
 
 ### Fixed

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -631,7 +631,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             DispatchQueue.main.async {
                 let alert = NSAlert()
                 alert.messageText = "Microphone Access Required"
-                alert.informativeText = "Hermes Agent needs microphone access for voice input. Enable it in System Settings \u2192 Privacy & Security \u2192 Microphone, then reload the page."
+                alert.informativeText = "Hermes Agent needs microphone access for voice input. Enable it in System Settings → Privacy & Security → Microphone, then reload the page."
                 alert.addButton(withTitle: "Open System Settings")
                 alert.addButton(withTitle: "Cancel")
                 if alert.runModal() == .alertFirstButtonReturn,

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -42,6 +42,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     /// Guards against onNavigationFailed firing twice (both provisional and 5xx paths
     /// can trigger on the same load event during teardown).
     private var didReportNavigationFailure = false
+    /// Throttle the mic-denied alert to once per app session — avoids spamming if the
+    /// user hits the mic button multiple times after having denied access.
+    private static var didShowMicDeniedAlert = false
     /// Set to true before programmatic close so windowDidExitFullScreen
     /// doesn't clobber the saved full-screen preference (fix #43).
     var isIntentionalClose = false
@@ -63,19 +66,21 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             defer: false
         )
         window.title = title
-        // Restore last window size + position (fix: window size resetting on launch).
-        // setFrameAutosaveName saves future changes but does NOT restore the saved frame —
-        // setFrameUsingName does the restore. For IB-created windows AppKit wires both;
-        // for code-created windows we must call both manually.
-        // setFrameUsingName returns false on first launch (no saved frame) — fall back to center().
-        window.setFrameAutosaveName("HermesMainWindow")
-        if !window.setFrameUsingName("HermesMainWindow") {
-            window.center()
-        }
         // Fix #23: set native window background to dark before content loads,
         // so there's no white frame visible while WKWebView is initializing.
         window.backgroundColor = .windowBackgroundColor
         super.init(window: window)
+
+        // Persist and restore window frame across launches.
+        // Must be set on the NSWindowController (self), not on the raw NSWindow.
+        // Setting it on the window before super.init is clobbered by the controller's
+        // own empty windowFrameAutosaveName during its setup. The controller property
+        // handles both save and restore atomically.
+        self.windowFrameAutosaveName = "HermesMainWindow"
+        // First launch (no saved frame yet): center the window.
+        if UserDefaults.standard.object(forKey: "NSWindow Frame HermesMainWindow") == nil {
+            window.center()
+        }
 
         window.onPaste = { [weak self] in
             self?.handlePaste()
@@ -618,7 +623,22 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                 DispatchQueue.main.async { decisionHandler(granted ? .grant : .deny) }
             }
         case .denied, .restricted:
+            // Deny immediately so WebKit doesn't wait on us, then surface a recovery path
+            // so the user knows how to re-grant access. Throttled to once per session.
             decisionHandler(.deny)
+            guard !Self.didShowMicDeniedAlert, type != .camera else { break }
+            Self.didShowMicDeniedAlert = true
+            DispatchQueue.main.async {
+                let alert = NSAlert()
+                alert.messageText = "Microphone Access Required"
+                alert.informativeText = "Hermes Agent needs microphone access for voice input. Enable it in System Settings \u2192 Privacy & Security \u2192 Microphone, then reload the page."
+                alert.addButton(withTitle: "Open System Settings")
+                alert.addButton(withTitle: "Cancel")
+                if alert.runModal() == .alertFirstButtonReturn,
+                   let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
         @unknown default:
             decisionHandler(.deny)
         }


### PR DESCRIPTION
## v1.3.3 — Fix mic permission regression and window size regression from v1.3.2

Both bugs are regressions introduced in v1.3.2. Apologies for the churn.

---

### Fix 1 — Microphone "access denied" with no prompt (regression from v1.3.2)

**Root cause:** v1.3.2 correctly removed the aggressive launch-time mic prompt, but deleted the recovery path along with it. Users whose TCC permission was already `.denied` (from ever clicking "Don't Allow" — including on the v1.3.1 launch-time alert) hit the `.denied, .restricted` branch in `requestMediaCapturePermissionFor`, which called `decisionHandler(.deny)` and returned silently. No alert, no path to System Settings, mic permanently broken from the user's perspective.

**Fix:** The `.denied, .restricted` branch now:
1. Calls `decisionHandler(.deny)` first (so WebKit doesn't wait on a blocking modal)
2. Shows a single "Open System Settings" alert pointing to Privacy & Security → Microphone
3. Throttled via `private static var didShowMicDeniedAlert` — fires at most once per app session, and only for mic (not camera)

Fresh users (TCC `.notDetermined`) still hit the correct branch: `AVCaptureDevice.requestAccess` shows the OS prompt once, result is returned to WebKit, TCC remembers it permanently.

### Fix 2 — Window size still resetting to 1280×830 (regression from v1.3.2)

**Root cause:** `NSWindowController` has its own `windowFrameAutosaveName` property that governs frame persistence for the controller. v1.3.2 set `setFrameAutosaveName` and called `setFrameUsingName` on the raw `NSWindow` *before* `super.init(window:)`. When `NSWindowController` initialises, its default empty `windowFrameAutosaveName` overwrites the window-level setting — so subsequent resizes were registered under no name and never persisted to UserDefaults.

**Fix:** Removed the window-level calls entirely. After `super.init(window:)`, set `self.windowFrameAutosaveName = "HermesMainWindow"` on the controller. AppKit's controller machinery handles both save (on every resize/move) and restore (on window display) atomically, correctly, for the lifetime of the controller. `center()` is guarded to first-launch only by checking for the absence of the UserDefaults key `"NSWindow Frame HermesMainWindow"`.

---

### Mac agent build verification (required before merge)

```
cd /tmp/swift-mac-test
git fetch origin && git checkout sprint-v1-3-3 && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1

/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

No new Info.plist keys, no new entitlements, no new frameworks.

**Manual verification recommended:**
- Deny mic access in System Settings → Privacy & Security → Microphone, launch app, click mic → should see "Open System Settings" alert (once per session)
- Resize window, quit, relaunch → window should open at the same size and position
