### PR TITLE
fix: v1.3.6 — build.sh embeds entitlements in local builds, stale test comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v1.3.6] — 2026-04-20
+
+### Fixed
+- **`build.sh` now embeds entitlements in local ad-hoc builds** — `codesign` in `build.sh`
+  was signing without `--entitlements Entitlements.plist`, so locally-built `.app` bundles
+  never had any embedded entitlements (including `com.apple.security.device.audio-input`).
+  CI was correct (it already passed `--entitlements`). Local builds now embed the same
+  entitlements as CI-signed DMGs, making mic and other entitlement-gated features testable
+  without a full CI run. (reviewer follow-up from #50)
+- **Stale comment in `LaunchBehaviorTests`** — the warm-up regression history comment still
+  referenced `default(for:)` and omitted the v1.3.5 entitlement root cause. Updated to
+  accurately describe the fix history through v1.3.5. (reviewer follow-up from #50)
+
 ## [v1.3.5] — 2026-04-20
 
 ### Fixed

--- a/Tests/HermesAgentTests/LaunchBehaviorTests.swift
+++ b/Tests/HermesAgentTests/LaunchBehaviorTests.swift
@@ -20,7 +20,10 @@ final class LaunchBehaviorTests: XCTestCase {
     /// even when TCC status is .authorized and the WKUIDelegate returns .grant.
     ///
     /// **History:** Deleted in v1.3.2 (it was part of the proactive prompt, which was rightly removed).
-    /// Mic broke for all users (v1.3.2, v1.3.3). Restored as a silent warm-up in v1.3.4 (PR #49).
+    /// Mic broke for all users (v1.3.2–v1.3.4). Root cause found in v1.3.5: Entitlements.plist used
+    /// `com.apple.security.device.microphone` (invalid) instead of `com.apple.security.device.audio-input`.
+    /// warm-up now uses `AVCaptureDevice.requestAccess` (contacts tccd) not `default(for:)` (IOKit only).
+    /// Fixed in v1.3.5 (PR #50).
     ///
     /// **If you're tempted to remove it:** don't. If you think it's redundant, check the above.
     /// The TCC status being .authorized is necessary but not sufficient — the host AVFoundation

--- a/build.sh
+++ b/build.sh
@@ -101,9 +101,11 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << PLIST
 PLIST
 
 echo "→ Signing (ad-hoc)..."
-# Sign the framework first, then the app
+# Sign the framework first, then the app bundle.
+# --entitlements embeds the plist so local builds match CI-signed DMGs.
+# Note: ad-hoc signing (sign -) does not verify entitlements; use CI for notarized builds.
 codesign --force --deep --sign - "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
-codesign --force --deep --sign - "$APP_BUNDLE"
+codesign --force --deep --sign - --entitlements Entitlements.plist "$APP_BUNDLE"
 
 echo "→ Installing to Applications..."
 rm -rf "/Applications/$APP_BUNDLE"


### PR DESCRIPTION
Reviewer follow-ups from #50: (1) `build.sh` codesign now passes `--entitlements Entitlements.plist` so local ad-hoc builds embed the same entitlements as CI DMGs — makes entitlement-gated features like mic testable locally without a CI run; (2) stale `default(for:)` reference in `LaunchBehaviorTests` updated to reflect the v1.3.5 root-cause fix. Zero behavior change to shipped DMGs (CI already had `--entitlements`).