### PR TITLE
feat: v1.4.0 — white flash fix, Cmd+F find bar, error UX cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [v1.4.0] — 2026-04-23
+
+### Fixed
+- **White flash on startup eliminated (for real this time)** — the window is now started
+  with `alphaValue = 0` and fades in (0.15s) on `didFinishNavigation` — the point at which
+  WKWebView has actually painted its first frame. A `hasCompletedFirstPaint` flag ensures
+  the animation only fires once; SPA route changes and Cmd+R reloads are unaffected.
+  Additionally, the NSWindow frame background and the WKWebView pre-paint `documentStart`
+  script are both set to `#1a1a1a` (dark) regardless of the system colour scheme, so any
+  gap between window-visible and first paint is never white in any situation. Closes #52.
+
+### Added
+- **Find in page — Cmd+F** — pressing Cmd+F opens a native find bar (NSSearchField overlay
+  with vibrancy) anchored below the title bar. `‹` / `›` buttons and Cmd+G / Cmd+Shift+G
+  cycle through results via `window.find()` JS. Pressing Done or Escape closes the bar.
+  Closes #37, closes #45.
+
+### Changed
+- **Connection error copy no longer hardcodes `~/hermes-webui-public`** — the error
+  window now says "Run: bash start.sh (or: docker compose up -d)" instead of the path
+  that only applied to one specific install layout. Closes #40.
+
 ## [v1.3.6] — 2026-04-20
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -159,6 +159,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if mode == "ssh", let host = sshHost, let port = localPort {
             browser.updateStatus(tunnelManager.status, host: host, port: port)
         }
+        // Fix #52: set alphaValue=0 BEFORE showWindow — prevents a brief
+        // visible-at-full-opacity tick. The window fades in on first WKWebView paint.
+        // backgroundColor is already set to #1a1a1a in BrowserWindowController.init.
+        browser.window?.alphaValue = 0
         browser.showWindow(nil)
         browserWindow = browser
 

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -5,10 +5,34 @@ import WebKit
 
 class BrowserWindow: NSWindow {
     var onPaste: (() -> Void)?
+    var onFind: (() -> Void)?
+    var onFindNext: (() -> Void)?
+    var onFindPrev: (() -> Void)?
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "v" {
+        // Cmd+V: route to the web view paste handler — but NOT when a native
+        // text field (e.g. the find bar's NSSearchField) is focused.
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.charactersIgnoringModifiers == "v",
+           !(firstResponder is NSText) {
             onPaste?()
+            return true
+        }
+        // Cmd+F: open find bar (fix #37/#45)
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.charactersIgnoringModifiers == "f" {
+            onFind?()
+            return true
+        }
+        // Cmd+G: find next; Cmd+Shift+G: find previous (fix #37/#45)
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.charactersIgnoringModifiers == "g" {
+            onFindNext?()
+            return true
+        }
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift],
+           event.charactersIgnoringModifiers == "G" {
+            onFindPrev?()
             return true
         }
         return super.performKeyEquivalent(with: event)
@@ -42,6 +66,13 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     /// Guards against onNavigationFailed firing twice (both provisional and 5xx paths
     /// can trigger on the same load event during teardown).
     private var didReportNavigationFailure = false
+    /// Tracks whether the first navigation paint has occurred, so the fade-in
+    /// animation (fix #52) only fires once — not on every SPA route change.
+    private var hasCompletedFirstPaint = false
+    // Find bar (fix #37/#45)
+    private var findBar: NSView?
+    private var findField: NSSearchField?
+    private var findBarVisible = false
     /// The UserDefaults autosave name for the main window frame.
     /// Used for both windowFrameAutosaveName and the derived "NSWindow Frame <name>" key.
     private static let windowAutosaveName = "HermesMainWindow"
@@ -69,9 +100,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             defer: false
         )
         window.title = title
-        // Fix #23: set native window background to dark before content loads,
-        // so there's no white frame visible while WKWebView is initializing.
-        window.backgroundColor = .windowBackgroundColor
+        // Fix #23 + #52: set native window background to a dark colour before
+        // content loads. Using a literal dark value (not windowBackgroundColor)
+        // ensures the gap between window-visible and first-paint is dark in
+        // *all* colour schemes — windowBackgroundColor is white in light mode.
+        window.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1.0)
         super.init(window: window)
 
         // Persist and restore window frame across launches.
@@ -87,6 +120,15 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
         window.onPaste = { [weak self] in
             self?.handlePaste()
+        }
+        window.onFind = { [weak self] in
+            self?.toggleFindBar()
+        }
+        window.onFindNext = { [weak self] in
+            self?.findNext(forward: true)
+        }
+        window.onFindPrev = { [weak self] in
+            self?.findNext(forward: false)
         }
         window.delegate = self
 
@@ -186,18 +228,21 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // before the first paint — otherwise the WebView renders white while
         // the dark theme is still loading from the server.
         if #available(macOS 12.0, *) {
-            webView.underPageBackgroundColor = .windowBackgroundColor
+            // Fix #52: match the pre-paint dark background so the overscroll gutter
+            // is dark too — not white, regardless of system colour scheme.
+            webView.underPageBackgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1.0)
         }
-        // Fallback for older OS: inject a documentStart script that sets the
-        // background immediately before the first paint.
+        // Fix #52: inject a documentStart script that always sets the document
+        // background to match our pre-paint NSWindow dark background (#1a1a1a),
+        // regardless of colour scheme. This eliminates any FOUC during the HTTP
+        // round-trip — even if the window becomes visible early, both the native
+        // frame and the WebView show the same dark colour.
+        // Once the app's actual CSS loads, it overrides this with the correct theme.
         let darkModeScript = WKUserScript(
             source: """
                 (function() {
-                    var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                    if (isDark) {
-                        document.documentElement.style.background = '#1a1a1a';
-                        document.body && (document.body.style.background = '#1a1a1a');
-                    }
+                    document.documentElement.style.background = '#1a1a1a';
+                    if (document.body) { document.body.style.background = '#1a1a1a'; }
                 })();
                 """,
             injectionTime: .atDocumentStart,
@@ -458,9 +503,21 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         }
     }
 
-    // MARK: - Zoom level restore (fix #43)
+    // MARK: - Zoom level restore (fix #43) + startup fade-in (fix #52)
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // Fix #52: fade the window in on the very first successful paint.
+        // Uses a bool flag (not alphaValue check) to be robust against any
+        // intermediate alpha changes. Subsequent navigations (SPA routes,
+        // Cmd+R reloads) see hasCompletedFirstPaint=true and skip the animation.
+        if !hasCompletedFirstPaint {
+            hasCompletedFirstPaint = true
+            NSAnimationContext.runAnimationGroup { ctx in
+                ctx.duration = 0.15
+                window?.animator().alphaValue = 1
+            }
+        }
+
         // Restore persisted zoom level. double(forKey:) returns 0.0 when unset —
         // treat any value outside the valid zoom range as "no preference".
         let saved = UserDefaults.standard.double(forKey: AppDelegate.zoomKey)
@@ -478,6 +535,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         _ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
+        // Fix #52: ensure the window is visible before we close/replace it.
+        // If the very first navigation fails, didFinishNavigation never fires,
+        // so the window stays at alphaValue=0. Restore it so the error window
+        // transition isn't invisible.
+        window?.alphaValue = 1
         let nsError = error as NSError
         // NSURLErrorCancelled fires for link clicks we redirected to Safari —
         // those aren't real failures, ignore them.
@@ -606,6 +668,123 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     func windowWillClose(_ notification: Notification) {
         stopHealthCheck()
+        hideFindBar()
+    }
+
+    // MARK: - Find in page (fix #37/#45, Cmd+F)
+    // Uses window.find() JS (macOS 12+ via WKWebView.evaluateJavaScript) with a
+    // native NSSearchField overlay. NSTextFinder bridging would give a more
+    // native look but requires implementing NSTextFinderClient over a WebView —
+    // not worth the complexity for a thin wrapper app.
+
+    private func toggleFindBar() {
+        if findBarVisible {
+            hideFindBar()
+        } else {
+            showFindBar()
+        }
+    }
+
+    private func showFindBar() {
+        guard findBar == nil, let contentView = window?.contentView else { return }
+        findBarVisible = true
+
+        let barHeight: CGFloat = 36
+        let bar = NSVisualEffectView(frame: NSRect(
+            x: 0, y: contentView.bounds.height - barHeight,
+            width: contentView.bounds.width, height: barHeight))
+        bar.autoresizingMask = [.width, .minYMargin]
+        bar.blendingMode = .withinWindow
+        bar.material = .headerView  // .titlebar is deprecated; .headerView is the modern equivalent
+        bar.state = .active
+        contentView.addSubview(bar)
+        findBar = bar
+
+        let field = NSSearchField(frame: NSRect(x: 8, y: 5, width: 220, height: 24))
+        field.placeholderString = "Find in page…"
+        field.sendsSearchStringImmediately = true
+        field.target = self
+        field.action = #selector(findFieldChanged(_:))
+        bar.addSubview(field)
+        findField = field
+
+        let prevBtn = NSButton(title: "\u{2039}", target: self, action: #selector(findPrevTapped))
+        prevBtn.bezelStyle = .rounded
+        prevBtn.font = NSFont.systemFont(ofSize: 15)
+        prevBtn.frame = NSRect(x: 234, y: 4, width: 28, height: 26)
+        bar.addSubview(prevBtn)
+
+        let nextBtn = NSButton(title: "\u{203A}", target: self, action: #selector(findNextTapped))
+        nextBtn.bezelStyle = .rounded
+        nextBtn.font = NSFont.systemFont(ofSize: 15)
+        nextBtn.frame = NSRect(x: 264, y: 4, width: 28, height: 26)
+        bar.addSubview(nextBtn)
+
+        let doneBtn = NSButton(title: "Done", target: self, action: #selector(findDoneTapped))
+        doneBtn.bezelStyle = .rounded
+        doneBtn.font = NSFont.systemFont(ofSize: 12)
+        doneBtn.frame = NSRect(x: 298, y: 4, width: 52, height: 26)
+        bar.addSubview(doneBtn)
+
+        // Shrink webView to make room for the bar
+        webView.frame.size.height -= barHeight
+        window?.makeFirstResponder(field)
+    }
+
+    private func hideFindBar() {
+        guard let bar = findBar else { return }
+        findBarVisible = false
+        bar.removeFromSuperview()
+        findBar = nil
+        findField = nil
+        // Restore webView height
+        if let contentView = window?.contentView {
+            let statusBarHeight: CGFloat = connectionMode == "ssh" ? 28 : 0
+            webView.frame = NSRect(
+                x: 0, y: statusBarHeight,
+                width: contentView.bounds.width,
+                height: contentView.bounds.height - statusBarHeight)
+        }
+        window?.makeFirstResponder(webView)
+    }
+
+    // cancelOperation is sent by AppKit when the user presses Escape while
+    // the find field is first responder. Closing the bar here satisfies the
+    // CHANGELOG claim that Escape dismisses the bar.
+    override func cancelOperation(_ sender: Any?) {
+        if findBarVisible {
+            hideFindBar()
+        } else {
+            super.cancelOperation(sender)
+        }
+    }
+
+    @objc private func findFieldChanged(_ sender: NSSearchField) {
+        runFind(query: sender.stringValue, forward: true)
+    }
+
+    @objc private func findNextTapped() { findNext(forward: true) }
+    @objc private func findPrevTapped() { findNext(forward: false) }
+    @objc private func findDoneTapped() { hideFindBar() }
+
+    private func findNext(forward: Bool) {
+        guard let q = findField?.stringValue, !q.isEmpty else {
+            if !findBarVisible { showFindBar() }
+            return
+        }
+        runFind(query: q, forward: forward)
+    }
+
+    private func runFind(query: String, forward: Bool) {
+        guard !query.isEmpty else { return }
+        // window.find(aString, caseSensitive, backwards, wrapAround, wholeWord, searchInFrames, showDialog)
+        // Escape backslashes and single-quotes to make the query safe inside the JS string literal.
+        let escaped = query
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+        let backwards = forward ? "false" : "true"
+        let js = "window.find('\(escaped)', false, \(backwards), true, false, true, false);"
+        webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
     // MARK: - Microphone / camera permissions

--- a/Sources/HermesAgent/ErrorWindowController.swift
+++ b/Sources/HermesAgent/ErrorWindowController.swift
@@ -46,7 +46,8 @@ class ErrorWindowController: NSWindowController {
 
         let descText = mode == "ssh"
             ? "The SSH tunnel may not be established, or hermes-webui may not be running on the remote server."
-            : "Make sure hermes-webui is running on the target URL. Start it with:\ncd ~/hermes-webui-public && bash start.sh"
+            : "Make sure hermes-webui is running and listening at the URL above.\n"
+              + "Run: bash start.sh (or: docker compose up -d)"
         let desc = NSTextField(wrappingLabelWithString: descText)
         desc.font = NSFont.systemFont(ofSize: 12)
         desc.textColor = .secondaryLabelColor


### PR DESCRIPTION
## Summary

v1.4.0 sprint: white flash fix (for real), Cmd+F find in page, and error UX cleanup.

---

## Changes

### Fix: white flash on startup — finally eliminated (closes #52)

Three-layer defence:

1. **`alphaValue = 0` before `showWindow`** in AppDelegate — the window is invisible when it first appears. No dark or white flash of any kind.
2. **Fade `0 → 1` (0.15s) in `didFinishNavigation`** — fires when WKWebView has actually painted its first frame. A `hasCompletedFirstPaint` bool flag ensures the animation fires exactly once; SPA route changes and Cmd+R reloads are unaffected.
3. **Dark background everywhere** — `NSWindow.backgroundColor`, `WKWebView.underPageBackgroundColor`, and the `documentStart` script all use `#1a1a1a` (not `windowBackgroundColor`, which is white in light mode). Any transient gap before the fade-in is dark regardless of system colour scheme.

If navigation fails before the first paint, `didFailProvisionalNavigation` restores `alphaValue = 1` before the error window takes over — no orphaned invisible window.

Previous fix attempts (v1.1.0: `underPageBackgroundColor` + dark-mode-only `documentStart` script) missed the NSWindow frame gap entirely and didn't help light mode users at all.

### Add: find in page — Cmd+F (closes #37, closes #45)

Pressing Cmd+F opens a native vibrancy bar (NSVisualEffectView, `.headerView` material) below the title bar with an NSSearchField. Results cycle via `window.find()` JS:

- Cmd+F: toggle find bar
- Cmd+G / `›` button: find next
- Cmd+Shift+G / `‹` button: find previous
- Done button or Escape: close

The Cmd+V paste intercept in `BrowserWindow.performKeyEquivalent` is now gated on `!(firstResponder is NSText)` so pasting into the find field works correctly.

Note: `WKFindInteraction` is iOS-only and won't compile on macOS — `window.find()` via JS evaluation is the correct macOS approach (as documented in #45).

### Change: error screen copy no longer hardcodes `~/hermes-webui-public` (closes #40)

Changed "Start it with: `cd ~/hermes-webui-public && bash start.sh`" to the more general "Run: bash start.sh (or: docker compose up -d)" which doesn't assume any specific install path and covers Docker users.

---

## Files changed

| File | What changed |
|------|-------------|
| `AppDelegate.swift` | Set `alphaValue = 0` before `showWindow` |
| `BrowserWindowController.swift` | Dark bg, fade-in on first paint, Cmd+F find bar, Cmd+V gate fix |
| `ErrorWindowController.swift` | Remove hardcoded `~/hermes-webui-public` path |
| `CHANGELOG.md` | v1.4.0 entry |

---

## Pre-merge checklist (for Mac agent)

```bash
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout sprint-v1-4-0 && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1

/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

Expected: build complete, all tests pass, bash build.sh produces Hermes Agent.app.

**Smoke test:** launch the built app, verify:
1. No white or dark flash on startup (window fades in cleanly)
2. Cmd+F opens the find bar, Escape closes it, Cmd+G cycles results
3. Cmd+V in the find field pastes text (not routed to webView)

Closes #52, closes #37, closes #45, closes #40.
Supersedes #53 (which will be closed).
