### PR TITLE
feat: v1.4.1 — add Edit → Find menu items for Cmd+F discoverability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.4.1] — 2026-04-23
+
+### Added
+- **Find submenu in Edit menu** — Edit → Find → Find… (Cmd+F), Find Next (Cmd+G),
+  Find Previous (Cmd+Shift+G). Makes the find feature discoverable via the standard
+  macOS menu convention instead of requiring users to know the shortcut.
+
 ## [v1.4.0] — 2026-04-23
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -313,6 +313,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
         editMenu.addItem(
             withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenu.addItem(.separator())
+        // Find submenu (fix #37/#45 — makes Cmd+F discoverable via menu)
+        let findMenuItem = NSMenuItem(title: "Find", action: nil, keyEquivalent: "")
+        let findMenu = NSMenu(title: "Find")
+        findMenu.addItem(
+            withTitle: "Find…", action: #selector(openFind), keyEquivalent: "f")
+        let findNextItem = NSMenuItem(
+            title: "Find Next", action: #selector(findNext), keyEquivalent: "g")
+        findMenu.addItem(findNextItem)
+        let findPrevItem = NSMenuItem(
+            title: "Find Previous", action: #selector(findPrev), keyEquivalent: "G")
+        findPrevItem.keyEquivalentModifierMask = [.command, .shift]
+        findMenu.addItem(findPrevItem)
+        findMenuItem.submenu = findMenu
+        editMenu.addItem(findMenuItem)
         let windowMenuItem = NSMenuItem()
         menuBar.addItem(windowMenuItem)
         let windowMenu = NSMenu(title: "Window")
@@ -361,6 +376,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func reloadPage() {
         browserWindow?.webViewForZoom?.reload()
+    }
+
+    // MARK: - Find forwarding (fix #37/#45 — menu items delegate to BrowserWindowController)
+
+    @objc func openFind() {
+        // Toggle the find bar — if already open, Cmd+F closes it (standard macOS behaviour)
+        (browserWindow?.window as? BrowserWindow)?.onFind?()
+    }
+
+    @objc func findNext() {
+        (browserWindow?.window as? BrowserWindow)?.onFindNext?()
+    }
+
+    @objc func findPrev() {
+        (browserWindow?.window as? BrowserWindow)?.onFindPrev?()
     }
 
     // MARK: - Open in system browser (bonus feature)


### PR DESCRIPTION
## Summary

Follow-up to v1.4.0 (#54): adds Edit → Find → Find… to the menu bar so Cmd+F is discoverable via the standard macOS menu convention.

## What changed

`AppDelegate.setupMenu()` — added a Find submenu under Edit:

```
Edit
  Undo           Cmd+Z
  Redo           Cmd+Shift+Z
  ──────────────
  Cut            Cmd+X
  Copy           Cmd+C
  Paste          Cmd+V
  Select All     Cmd+A
  ──────────────
  Find ▶
    Find…        Cmd+F
    Find Next    Cmd+G
    Find Previous Cmd+Shift+G
```

The three menu actions (`openFind`, `findNext`, `findPrev`) forward directly to the `BrowserWindow`'s existing `onFind`/`onFindNext`/`onFindPrev` closures — no changes to `BrowserWindowController`.

## Pre-merge checklist (for Mac agent)

```bash
cd /tmp/swift-mac-test
git fetch origin && git checkout fix/find-menu-item && git pull --rebase

swift build -c release 2>&1
swift test 2>&1
```

Smoke test: launch app, check Edit menu has Find → Find… (Cmd+F), Find Next (Cmd+G), Find Previous (Cmd+Shift+G). Click Find… to confirm it opens the bar.

Closes #37 (menu discoverability aspect — the bar itself shipped in v1.4.0).
