### PR TITLE
feat: v1.5.0 — full-size content view (#57), configurable hotkey (#41), session persistence (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [v1.5.0] — 2026-04-25
+
+### Added
+- **Configurable global hotkey** — the hardcoded Cmd+Shift+H shortcut is now user-configurable
+  in Preferences. Click the new recorder field to arm it, press any combo with Cmd/Ctrl/Option,
+  and the shortcut updates immediately. Press Delete while recording to clear (disable) the
+  hotkey. The combo is persisted in UserDefaults and survives app restarts. Closes #41.
+
+### Changed
+- **Full-size content view** — web content now extends under the native macOS title bar using
+  `.fullSizeContentView` + `titlebarAppearsTransparent`. The web app's custom `.app-titlebar`
+  element sits in the title-bar region, eliminating the doubled native/web header. Traffic
+  lights stay visible via a `--traffic-light-width` CSS custom property (default `80px`,
+  refined to the exact measured value after first paint). The variable resets to `0px` in
+  fullscreen and restores on exit. Closes #57.
+
+### Fixed
+- **Session state preserved on reconnect** — tunnel drops, network blips, and manual reconnects
+  no longer destroy the WKWebView. The existing browser window is hidden (orderOut) and reused
+  on reconnect via `reconnectInPlace()`, preserving localStorage, cookies, IndexedDB, and
+  scroll position. The WKWebView is only replaced when the error window takes over on a failed
+  reconnect. Closes #10.
+
 ## [v1.4.1] — 2026-04-23
 
 ### Added

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -38,7 +38,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Register non-persistent defaults so users upgrading from v1.1.0
         // (where notifications were always on) don't silently lose them.
         // seedDefaultsIfNeeded only persists on first-ever launch.
-        UserDefaults.standard.register(defaults: ["notificationsEnabled": true])
+        UserDefaults.standard.register(defaults: [
+            "notificationsEnabled": true,
+            // Fix #41: default global hotkey = Cmd+Shift+H
+            "globalHotkeyKeyCode": kVK_ANSI_H,
+            "globalHotkeyModifiers": Int(cmdKey | shiftKey),
+            "globalHotkeyEnabled": true,
+        ])
 
         // Initialize Sparkle updater — feed URL comes from SUFeedURL in Info.plist
         updaterController = SPUStandardUpdaterController(
@@ -76,9 +82,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let splashSubtitle = connectionMode == "ssh" ? "Establishing SSH tunnel…" : "Connecting…"
         splashWindow = SplashWindowController(title: appTitle, subtitle: splashSubtitle)
         splashWindow.showWindow(nil)
-        browserWindow?.isIntentionalClose = true
-        browserWindow?.close()
-        browserWindow = nil
+        // Fix #10: if the browser window is alive AND the connection mode hasn't changed,
+        // hide it (orderOut) and reuse the WKWebView to preserve session state.
+        // A mode switch (direct↔ssh) must rebuild the window to get the correct status bar.
+        let reuseWindow = browserWindow != nil &&
+            browserWindow?.connectionMode == connectionMode
+        if reuseWindow {
+            browserWindow?.window?.orderOut(nil)
+        } else {
+            browserWindow?.isIntentionalClose = true
+            browserWindow?.close()
+            browserWindow = nil
+        }
         errorWindow?.close()
         errorWindow = nil
         tunnelManager?.stop()
@@ -110,13 +125,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     self.splashWindow.close()
                     if self.tunnelManager.status == .connected {
-                        self.openBrowser(
-                            targetURL: targetURL,
-                            mode: "ssh",
-                            sshHost: host,
-                            localPort: localPort
-                        )
+                        if reuseWindow, let existing = self.browserWindow {
+                            // Fix #10: reuse existing WKWebView for session continuity.
+                            existing.reconnectInPlace(targetURL: targetURL)
+                            existing.window?.makeKeyAndOrderFront(nil)
+                            self.setOfflineBadge(false)
+                        } else {
+                            self.openBrowser(
+                                targetURL: targetURL,
+                                mode: "ssh",
+                                sshHost: host,
+                                localPort: localPort
+                            )
+                        }
                     } else {
+                        self.browserWindow = nil  // abandon the hidden window
                         self.showErrorWindow(targetURL: targetURL, mode: "ssh")
                     }
                 }
@@ -126,13 +149,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 DispatchQueue.main.async {
                     self.splashWindow.close()
                     if reachable {
-                        self.openBrowser(
-                            targetURL: targetURL,
-                            mode: "direct",
-                            sshHost: nil,
-                            localPort: nil
-                        )
+                        if reuseWindow, let existing = self.browserWindow {
+                            // Fix #10: reuse existing WKWebView for session continuity.
+                            existing.reconnectInPlace(targetURL: targetURL)
+                            existing.window?.makeKeyAndOrderFront(nil)
+                            self.setOfflineBadge(false)
+                        } else {
+                            self.openBrowser(
+                                targetURL: targetURL,
+                                mode: "direct",
+                                sshHost: nil,
+                                localPort: nil
+                            )
+                        }
                     } else {
+                        self.browserWindow = nil  // abandon the hidden window
                         self.showErrorWindow(targetURL: targetURL, mode: "direct")
                     }
                 }
@@ -427,6 +458,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if preferencesWindow == nil {
             preferencesWindow = PreferencesWindowController()
             preferencesWindow?.onSave = { [weak self] in
+                self?.reloadGlobalHotkey()  // Fix #41: apply new hotkey from UserDefaults
                 self?.preferencesWindow = nil
                 self?.startTunnel()
             }
@@ -439,7 +471,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Uses Carbon RegisterEventHotKey — works without Accessibility permission,
     // fires from any app immediately on first launch.
 
+    // MARK: - Global hotkey (configurable, fix #6 + #41)
+
     private func setupGlobalHotkey() {
+        let defaults = UserDefaults.standard
+        // Fix #41: check enabled flag; skip registration when user cleared the shortcut.
+        guard defaults.bool(forKey: "globalHotkeyEnabled") else { return }
+        let keyCode = UInt32(defaults.integer(forKey: "globalHotkeyKeyCode"))
+        let mods    = UInt32(defaults.integer(forKey: "globalHotkeyModifiers"))
+
         var eventSpec = EventTypeSpec(
             eventClass: OSType(kEventClassKeyboard),
             eventKind: UInt32(kEventHotKeyPressed)
@@ -449,31 +489,53 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
         // InstallApplicationEventHandler is a C macro Swift can't import — call
         // the underlying InstallEventHandler with GetApplicationEventTarget() directly.
-        InstallEventHandler(
-            GetApplicationEventTarget(),
-            { _, _, userData -> OSStatus in
-                guard let ptr = userData else { return noErr }
-                let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
-                DispatchQueue.main.async {
-                    delegate.browserWindow?.showWindow(nil)
-                    delegate.browserWindow?.window?.makeKeyAndOrderFront(nil)
-                    NSApp.activate(ignoringOtherApps: true)
-                }
-                return noErr
-            },
-            1, &eventSpec, selfPtr, &carbonEventHandler
-        )
+        // Install only once; carbonEventHandler is reused on reloadGlobalHotkey.
+        if carbonEventHandler == nil {
+            InstallEventHandler(
+                GetApplicationEventTarget(),
+                { _, _, userData -> OSStatus in
+                    guard let ptr = userData else { return noErr }
+                    let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
+                    DispatchQueue.main.async {
+                        delegate.browserWindow?.showWindow(nil)
+                        delegate.browserWindow?.window?.makeKeyAndOrderFront(nil)
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                    return noErr
+                },
+                1, &eventSpec, selfPtr, &carbonEventHandler
+            )
+        }
         let hkID = EventHotKeyID(signature: OSType(0x4845_524D), id: 1)  // 'HERM'
         let status = RegisterEventHotKey(
-            UInt32(kVK_ANSI_H),
-            UInt32(cmdKey | shiftKey),
+            keyCode,
+            mods,
             hkID,
             GetApplicationEventTarget(),
             0,
             &carbonHotKeyRef
         )
         if status != noErr {
-            NSLog("[HermesAgent] RegisterEventHotKey failed (OSStatus %d) — Cmd+Shift+H may already be claimed by another app.", status)
+            NSLog("[HermesAgent] RegisterEventHotKey failed (OSStatus %d)", status)
+        }
+    }
+
+    /// Re-register the global hotkey with the current UserDefaults values.
+    /// Called from Preferences save when the user changes the shortcut.
+    /// Only unregisters the hotkey ref — the event handler stays installed.
+    func reloadGlobalHotkey() {
+        if let ref = carbonHotKeyRef {
+            UnregisterEventHotKey(ref)
+            carbonHotKeyRef = nil
+        }
+        setupGlobalHotkey()
+        // Warn the user if the new shortcut couldn't be registered
+        // (e.g. Cmd+Space is claimed by Spotlight).
+        if UserDefaults.standard.bool(forKey: "globalHotkeyEnabled") && carbonHotKeyRef == nil {
+            let alert = NSAlert()
+            alert.messageText = "Shortcut unavailable"
+            alert.informativeText = "This shortcut is already claimed by another app. Try a different combination."
+            alert.runModal()
         }
     }
 

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -58,9 +58,9 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private var statusDot: NSView!
     private var statusLabel: NSTextField!
     private var reconnectButton: NSButton!
-    private let urlString: String
+    private(set) var urlString: String
     private let appTitle: String
-    private let connectionMode: String
+    private(set) var connectionMode: String
     var onReconnect: (() -> Void)?
     var onNavigationFailed: (() -> Void)?
     /// Guards against onNavigationFailed firing twice (both provisional and 5xx paths
@@ -95,7 +95,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
         let window = BrowserWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1280, height: 830),
-            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -106,6 +106,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // *all* colour schemes — windowBackgroundColor is white in light mode.
         window.backgroundColor = NSColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1.0)
         super.init(window: window)
+
+        // Fix #57: extend web content under the native title bar.
+        // titleVisibility = .hidden removes the text draw; window.title stays set
+        // (Window menu, Dock, accessibility, Mission Control).
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
 
         // Persist and restore window frame across launches.
         // Must be set on the NSWindowController (self), not on the raw NSWindow.
@@ -249,6 +255,15 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             forMainFrameOnly: true
         )
         config.userContentController.addUserScript(darkModeScript)
+
+        // Fix #57: inject default traffic light clearance at documentStart.
+        // Refined to exact measured pixels in injectTrafficLightWidthVar() after didFinish.
+        let trafficLightScript = WKUserScript(
+            source: "document.documentElement.style.setProperty('--traffic-light-width', '80px');",
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(trafficLightScript)
 
         contentView.addSubview(webView)
 
@@ -518,12 +533,33 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             }
         }
 
+        // Fix #57: refine traffic light clearance to exact measured value.
+        injectTrafficLightWidthVar()
+
         // Restore persisted zoom level. double(forKey:) returns 0.0 when unset —
         // treat any value outside the valid zoom range as "no preference".
         let saved = UserDefaults.standard.double(forKey: AppDelegate.zoomKey)
         if saved >= 0.5 && saved <= 3.0 {
             webView.magnification = saved
         }
+    }
+
+    /// Measures the actual right edge of the zoom (green) traffic light button and
+    /// injects it as --traffic-light-width CSS custom property so the web title bar
+    /// leaves correct clearance. Called after first paint and fullscreen transitions.
+    private func injectTrafficLightWidthVar() {
+        let reserve: CGFloat
+        if let zoom = window?.standardWindowButton(.zoomButton) {
+            // .frame is in NSThemeFrame coords = window-space in the title-bar strip.
+            reserve = zoom.frame.maxX + 12
+        } else {
+            reserve = 80
+        }
+        let px = Int(reserve)
+        webView.evaluateJavaScript(
+            "document.documentElement.style.setProperty('--traffic-light-width', '\(px)px');",
+            completionHandler: nil
+        )
     }
 
     // MARK: - Navigation failure
@@ -658,12 +694,42 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     func windowDidEnterFullScreen(_ notification: Notification) {
         UserDefaults.standard.set(true, forKey: "windowWasFullScreen")
+        // Fix #57: in fullscreen the traffic lights are gone; reset clearance to 0.
+        webView.evaluateJavaScript(
+            "document.documentElement.style.setProperty('--traffic-light-width', '0px');",
+            completionHandler: nil
+        )
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
         // Don't clobber the saved preference during a programmatic reconnect close.
         guard !isIntentionalClose else { return }
         UserDefaults.standard.set(false, forKey: "windowWasFullScreen")
+        // Fix #57: restore traffic light clearance after exiting fullscreen.
+        injectTrafficLightWidthVar()
+    }
+
+    // MARK: - Reconnect in place (fix #10)
+
+    /// Reconnect without destroying the WKWebView, preserving cookies,
+    /// localStorage, IndexedDB, and scroll position. Called by AppDelegate
+    /// when a reconnect is needed and the window is still alive.
+    func reconnectInPlace(targetURL newURLString: String) {
+        // Reset dedup flag so a real failure on this attempt routes to error window.
+        didReportNavigationFailure = false
+        // Defensive: ensures windowDidExitFullScreen doesn't no-op after reconnect.
+        isIntentionalClose = false
+        // Stop in-flight provisional load to prevent zombie didFailProvisionalNavigation.
+        webView.stopLoading()
+        let sameURL = (newURLString == urlString)
+        if sameURL {
+            webView.reload()
+        } else {
+            urlString = newURLString
+            if let url = URL(string: newURLString) {
+                webView.load(URLRequest(url: url))
+            }
+        }
     }
 
     func windowWillClose(_ notification: Notification) {
@@ -690,8 +756,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         findBarVisible = true
 
         let barHeight: CGFloat = 36
+        // Fix #57 interaction: with .fullSizeContentView the contentView extends under
+        // the title bar. Use contentLayoutRect (the area BELOW the title bar) so the
+        // find bar anchors below the traffic lights, not behind them.
+        let layoutTop = window.map { $0.contentLayoutRect.maxY } ?? contentView.bounds.height
         let bar = NSVisualEffectView(frame: NSRect(
-            x: 0, y: contentView.bounds.height - barHeight,
+            x: 0, y: layoutTop - barHeight,
             width: contentView.bounds.width, height: barHeight))
         bar.autoresizingMask = [.width, .minYMargin]
         bar.blendingMode = .withinWindow
@@ -737,13 +807,14 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         bar.removeFromSuperview()
         findBar = nil
         findField = nil
-        // Restore webView height
-        if let contentView = window?.contentView {
+        // Restore webView to its normal frame (below title bar, above status bar)
+        if let win = window, let contentView = win.contentView {
             let statusBarHeight: CGFloat = connectionMode == "ssh" ? 28 : 0
+            let layoutTop = win.contentLayoutRect.maxY
             webView.frame = NSRect(
                 x: 0, y: statusBarHeight,
                 width: contentView.bounds.width,
-                height: contentView.bounds.height - statusBarHeight)
+                height: layoutTop - statusBarHeight)
         }
         window?.makeFirstResponder(webView)
     }

--- a/Sources/HermesAgent/HotkeyRecorderView.swift
+++ b/Sources/HermesAgent/HotkeyRecorderView.swift
@@ -1,0 +1,215 @@
+import Cocoa
+import Carbon.HIToolbox
+
+// MARK: - Hotkey recorder view (fix #41)
+//
+// A click-to-arm NSView that captures a key combination and displays it symbolically.
+// Used in PreferencesWindowController to let the user configure the global shortcut.
+//
+// Usage:
+//   let recorder = HotkeyRecorderView(frame: ...)
+//   recorder.keyCode = UInt32(defaults.integer(forKey: "globalHotkeyKeyCode"))
+//   recorder.modifiers = UInt32(defaults.integer(forKey: "globalHotkeyModifiers"))
+//   recorder.onCapture = { keyCode, mods in
+//       defaults.set(Int(keyCode), forKey: "globalHotkeyKeyCode")
+//       defaults.set(Int(mods), forKey: "globalHotkeyModifiers")
+//   }
+//   recorder.onClear = {
+//       defaults.set(false, forKey: "globalHotkeyEnabled")
+//   }
+
+final class HotkeyRecorderView: NSView {
+
+    /// Called when the user presses a valid combo. keyCode and mods are Carbon values.
+    var onCapture: ((_ keyCode: UInt32, _ carbonMods: UInt32) -> Void)?
+    /// Called when the user clears the shortcut (presses Delete/Backspace in record mode).
+    var onClear: (() -> Void)?
+
+    /// Current key code (Carbon kVK_* constant). Set before display.
+    var keyCode: UInt32 = UInt32(kVK_ANSI_H)
+    /// Current modifiers (Carbon cmdKey | shiftKey etc.). Set before display.
+    var modifiers: UInt32 = UInt32(cmdKey | shiftKey)
+    /// Whether a shortcut is currently active (false = cleared/disabled).
+    var isEnabled: Bool = true
+
+    private var isRecording = false
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func becomeFirstResponder() -> Bool {
+        isRecording = true
+        needsDisplay = true
+        return true
+    }
+
+    override func resignFirstResponder() -> Bool {
+        isRecording = false
+        needsDisplay = true
+        return true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+        // Bare Delete/Backspace (no modifiers) in recording mode clears the shortcut.
+        // Cmd+Delete, Ctrl+Delete, etc. can still be bound as hotkeys — let them fall through.
+        let usableModsForClear: NSEvent.ModifierFlags = [.command, .control, .option]
+        let hasMod = !flags.intersection(usableModsForClear).isEmpty
+        if !hasMod && (event.keyCode == UInt16(kVK_Delete) || event.keyCode == UInt16(kVK_ForwardDelete)) {
+            isEnabled = false
+            isRecording = false
+            needsDisplay = true
+            window?.makeFirstResponder(nil)
+            onClear?()
+            return
+        }
+
+        // Escape cancels recording without changing the shortcut.
+        if event.keyCode == UInt16(kVK_Escape) {
+            isRecording = false
+            needsDisplay = true
+            window?.makeFirstResponder(nil)
+            return
+        }
+
+        // Require at least one of Cmd/Ctrl/Option to avoid registering plain letter keys
+        // as global hotkeys (e.g. bare "h" would intercept normal typing everywhere).
+        guard !flags.intersection(usableModsForClear).isEmpty else {
+            NSSound.beep()
+            return
+        }
+
+        keyCode = UInt32(event.keyCode)
+        modifiers = HotkeyRecorderView.carbonFlags(from: flags)
+        isEnabled = true
+        isRecording = false
+        needsDisplay = true
+        window?.makeFirstResponder(nil)
+        onCapture?(keyCode, modifiers)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let bg = isRecording
+            ? NSColor.controlAccentColor.withAlphaComponent(0.12)
+            : NSColor.controlBackgroundColor
+        bg.setFill()
+        NSBezierPath(roundedRect: bounds, xRadius: 5, yRadius: 5).fill()
+
+        NSColor.separatorColor.setStroke()
+        let borderPath = NSBezierPath(roundedRect: bounds.insetBy(dx: 0.5, dy: 0.5),
+                                      xRadius: 5, yRadius: 5)
+        borderPath.lineWidth = 1
+        borderPath.stroke()
+
+        let text: String
+        let color: NSColor
+        if isRecording {
+            text = "Type a shortcut\u{2026}"
+            color = .secondaryLabelColor
+        } else if !isEnabled {
+            text = "None"
+            color = .tertiaryLabelColor
+        } else {
+            text = HotkeyRecorderView.displayString(keyCode: keyCode, carbonMods: modifiers)
+            color = .labelColor
+        }
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 13),
+            .foregroundColor: color,
+        ]
+        let size = (text as NSString).size(withAttributes: attrs)
+        let pt = NSPoint(
+            x: (bounds.width - size.width) / 2,
+            y: (bounds.height - size.height) / 2
+        )
+        (text as NSString).draw(at: pt, withAttributes: attrs)
+    }
+
+    // MARK: - Key display helpers
+
+    /// Render a Carbon keycode + modifiers as macOS symbols (e.g. "\u{2318}\u{21E7}H").
+    static func displayString(keyCode: UInt32, carbonMods: UInt32) -> String {
+        var s = ""
+        if carbonMods & UInt32(controlKey) != 0 { s += "\u{2303}" }  // ⌃
+        if carbonMods & UInt32(optionKey)  != 0 { s += "\u{2325}" }  // ⌥
+        if carbonMods & UInt32(shiftKey)   != 0 { s += "\u{21E7}" }  // ⇧
+        if carbonMods & UInt32(cmdKey)     != 0 { s += "\u{2318}" }  // ⌘
+        s += keyName(for: keyCode)
+        return s
+    }
+
+    // Non-printing keys mapped to Unicode symbols.
+    private static let symbolicNames: [Int: String] = [
+        kVK_Return:       "\u{21A9}",  // ↩
+        kVK_Tab:          "\u{21E5}",  // ⇥
+        kVK_Space:        "\u{2423}",  // ␣
+        kVK_Delete:       "\u{232B}",  // ⌫
+        kVK_ForwardDelete:"\u{2326}",  // ⌦
+        kVK_Escape:       "\u{238B}",  // ⎋
+        kVK_LeftArrow:    "\u{2190}",  // ←
+        kVK_RightArrow:   "\u{2192}",  // →
+        kVK_UpArrow:      "\u{2191}",  // ↑
+        kVK_DownArrow:    "\u{2193}",  // ↓
+        kVK_Home:         "\u{2196}",  // ↖
+        kVK_End:          "\u{2198}",  // ↘
+        kVK_PageUp:       "\u{21DE}",  // ⇞
+        kVK_PageDown:     "\u{21DF}",  // ⇟
+        kVK_F1:  "F1",  kVK_F2:  "F2",  kVK_F3:  "F3",  kVK_F4:  "F4",
+        kVK_F5:  "F5",  kVK_F6:  "F6",  kVK_F7:  "F7",  kVK_F8:  "F8",
+        kVK_F9:  "F9",  kVK_F10: "F10", kVK_F11: "F11", kVK_F12: "F12",
+    ]
+
+    /// Convert a Carbon keycode to its display label using UCKeyTranslate (respects
+    /// the current keyboard layout) for printable keys, and a symbol table for
+    /// non-printing keys (arrows, function keys, etc.).
+    private static func keyName(for keyCode: UInt32) -> String {
+        if let sym = symbolicNames[Int(keyCode)] { return sym }
+
+        guard let src = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let layoutDataPtr = TISGetInputSourceProperty(src, kTISPropertyUnicodeKeyLayoutData)
+        else { return "?" }
+
+        // Get-style API: TISGetInputSourceProperty returns a +0 (unretained) reference.
+        // Using takeUnretainedValue — don't release it (the input source owns it).
+        let layoutData = Unmanaged<CFData>.fromOpaque(layoutDataPtr).takeUnretainedValue() as Data
+        var deadKeyState: UInt32 = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        var actualLength = 0
+
+        let result = layoutData.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> OSStatus in
+            let layout = raw.baseAddress!.assumingMemoryBound(to: UCKeyboardLayout.self)
+            return UCKeyTranslate(
+                layout,
+                UInt16(keyCode),
+                UInt16(kUCKeyActionDisplay),
+                0,
+                UInt32(LMGetKbdType()),
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState,
+                chars.count,
+                &actualLength,
+                &chars
+            )
+        }
+
+        guard result == noErr, actualLength > 0 else { return "?" }
+        return String(utf16CodeUnits: chars, count: actualLength).uppercased()
+    }
+
+    // MARK: - Modifier conversion
+
+    /// Convert NSEvent.ModifierFlags to Carbon modifier int for RegisterEventHotKey.
+    static func carbonFlags(from flags: NSEvent.ModifierFlags) -> UInt32 {
+        var m: UInt32 = 0
+        if flags.contains(.command) { m |= UInt32(cmdKey) }
+        if flags.contains(.option)  { m |= UInt32(optionKey) }
+        if flags.contains(.shift)   { m |= UInt32(shiftKey) }
+        if flags.contains(.control) { m |= UInt32(controlKey) }
+        return m
+    }
+}

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -15,10 +15,15 @@ class PreferencesWindowController: NSWindowController {
     private var testResultLabel: NSTextField!
     private var launchAtLoginCheckbox: NSButton!
     private var notificationsCheckbox: NSButton!
+    private var hotkeyRecorder: HotkeyRecorderView!  // Fix #41
+    // Pending hotkey edits — written to UserDefaults only on Save (not immediately)
+    private var pendingHotkeyKeyCode: UInt32?
+    private var pendingHotkeyModifiers: UInt32?
+    private var pendingHotkeyEnabled: Bool?
 
     init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 520, height: 592),
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 628),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -35,7 +40,7 @@ class PreferencesWindowController: NSWindowController {
         let content = window!.contentView!
         // Starting y must shift with the window height bump; otherwise the new
         // Notifications row pushes launchAtLogin into the Save/Cancel buttons.
-        var y: CGFloat = 532
+        var y: CGFloat = 568
 
         func sectionHeader(_ text: String) -> NSTextField {
             let label = NSTextField(labelWithString: text)
@@ -132,17 +137,35 @@ class PreferencesWindowController: NSWindowController {
         targetURLField = row(
             "Target URL", placeholder: "http://localhost:8787", defaultsKey: "targetURL")
 
-        // Global shortcut hint (fix #35)
+        // Fix #41: configurable global shortcut — replaced static label with recorder.
         let shortcutLabel = NSTextField(labelWithString: "Global shortcut:")
         shortcutLabel.font = NSFont.systemFont(ofSize: 13)
         shortcutLabel.frame = NSRect(x: 24, y: y, width: 130, height: 22)
         shortcutLabel.alignment = .right
         content.addSubview(shortcutLabel)
-        let shortcutValue = NSTextField(labelWithString: "⌘⇧H — bring Hermes forward from any app")
-        shortcutValue.font = NSFont.systemFont(ofSize: 13)
-        shortcutValue.textColor = .secondaryLabelColor
-        shortcutValue.frame = NSRect(x: 164, y: y, width: 330, height: 22)
-        content.addSubview(shortcutValue)
+
+        let hkDefaults = UserDefaults.standard
+        hotkeyRecorder = HotkeyRecorderView(frame: NSRect(x: 164, y: y - 1, width: 140, height: 24))
+        hotkeyRecorder.keyCode   = UInt32(hkDefaults.integer(forKey: "globalHotkeyKeyCode"))
+        hotkeyRecorder.modifiers = UInt32(hkDefaults.integer(forKey: "globalHotkeyModifiers"))
+        hotkeyRecorder.isEnabled = hkDefaults.bool(forKey: "globalHotkeyEnabled")
+        // Fix #41: defer UserDefaults writes to save() so Cancel discards changes.
+        hotkeyRecorder.onCapture = { [weak self] keyCode, mods in
+            self?.pendingHotkeyKeyCode = keyCode
+            self?.pendingHotkeyModifiers = mods
+            self?.pendingHotkeyEnabled = true
+        }
+        hotkeyRecorder.onClear = { [weak self] in
+            self?.pendingHotkeyEnabled = false
+        }
+        content.addSubview(hotkeyRecorder)
+
+        let hintLabel = NSTextField(labelWithString: "click to change, Delete to clear")
+        hintLabel.font = NSFont.systemFont(ofSize: 11)
+        hintLabel.textColor = .tertiaryLabelColor
+        hintLabel.frame = NSRect(x: 312, y: y + 1, width: 182, height: 20)
+        content.addSubview(hintLabel)
+
         y -= 36
 
         // Notifications toggle (fix #28)
@@ -299,6 +322,10 @@ class PreferencesWindowController: NSWindowController {
             defaults.set(targetURL.absoluteString, forKey: "targetURL")
         }
 
+        // Fix #41: persist pending hotkey edits if any (defer model prevents Cancel wiping them)
+        if let kc = pendingHotkeyKeyCode   { UserDefaults.standard.set(Int(kc), forKey: "globalHotkeyKeyCode") }
+        if let m  = pendingHotkeyModifiers  { UserDefaults.standard.set(Int(m),  forKey: "globalHotkeyModifiers") }
+        if let en = pendingHotkeyEnabled    { UserDefaults.standard.set(en, forKey: "globalHotkeyEnabled") }
         close()
         onSave?()
     }


### PR DESCRIPTION
## Summary

Three quality-of-life improvements in one sprint: full-size content view, configurable global hotkey, and session persistence across reconnects.

---

## Changes

### Full-size content view — closes #57

Web content now extends under the native macOS title bar. The web app's custom `.app-titlebar` element (shipped with the transcript redesign in web UI PR #587, now merged) fills the title bar region, eliminating the doubled native/web header.

**Implementation:**
- `BrowserWindowController.init`: added `.fullSizeContentView` to styleMask + `titlebarAppearsTransparent = true` + `titleVisibility = .hidden` (window title stays set for accessibility, Dock, Window menu)
- `injectTrafficLightWidthVar()`: new helper that measures `window.standardWindowButton(.zoomButton)?.frame.maxX + 12` and injects it as `--traffic-light-width` CSS custom property. Default `80px` at documentStart, refined to exact pixels in `didFinish`.
- `windowDidEnterFullScreen`: resets var to `0px` (traffic lights gone in fullscreen)
- `windowDidExitFullScreen`: restores measured value
- Find bar anchored to `window.contentLayoutRect` (not `contentView.bounds`) to avoid overlapping traffic lights

### Configurable global hotkey — closes #41

The hardcoded Cmd+Shift+H is now user-configurable in Preferences.

**Implementation:**
- New file: `HotkeyRecorderView.swift` — NSView subclass that arms on click, captures the next keyDown with Cmd/Ctrl/Option modifier, displays the combo symbolically (⌘⇧H etc.). Uses `UCKeyTranslate` for keyboard-layout-aware display of printable keys. Bare Delete clears the shortcut; Cmd+Delete can still be bound.
- `PreferencesWindowController`: replaced static label with `HotkeyRecorderView` + hint label. Changes are staged in pending vars and only written to UserDefaults on Save (Cancel discards).
- `AppDelegate.setupGlobalHotkey()`: reads keyCode/modifiers from UserDefaults (defaults registered at launch). `carbonEventHandler` installed once; only `carbonHotKeyRef` is re-registered on Preferences save.
- `AppDelegate.reloadGlobalHotkey()`: unregisters old hotkey ref, calls `setupGlobalHotkey()` with new values, shows NSAlert if registration fails (e.g. Cmd+Space claimed by Spotlight).

### Session persistence on reconnect — closes #10

Tunnel drops, network blips, and manual reconnects no longer destroy the WKWebView. localStorage, cookies, IndexedDB, and scroll position survive.

**Implementation:**
- `BrowserWindowController.reconnectInPlace(targetURL:)`: calls `webView.stopLoading()` then `reload()` (same URL) or `load()` (URL changed). Resets `didReportNavigationFailure` and `isIntentionalClose` defensively.
- `AppDelegate.startTunnel()`: `reuseWindow = browserWindow != nil && browserWindow?.connectionMode == connectionMode`. On reuse: `orderOut(nil)` (hide, don't destroy) + call `reconnectInPlace()` on success. On failure or mode switch: fall back to full window rebuild.
- `urlString` and `connectionMode` on `BrowserWindowController` changed from `private let` to `private(set) var` to support URL/mode updates.

---

## Pre-merge checklist

- [ ] **Mac agent build verification** (required — Swift cannot run on the Linux server):

```bash
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout sprint-v1.5.0 && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1

/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "Hermes Agent.app/Contents/Info.plist"
/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "Hermes Agent.app/Contents/Info.plist"
```

Expected: build complete, all tests pass, `bash build.sh` produces Hermes Agent.app.

- [ ] Independent review from nesquena account
- [ ] Verify traffic lights align correctly (not obscured by web content)
- [ ] Verify Preferences hotkey recorder: click to arm, press combo, Save, shortcut fires
- [ ] Verify session persists across Cmd+R reconnect and tunnel drop

---

Closes #57, closes #41, closes #10
