### PR TITLE
fix: v1.5.1 — hide .app-titlebar-icon overlapping traffic lights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.5.1] — 2026-04-25
+
+### Fixed
+- **Title bar icon no longer overlaps traffic lights** — the web app's `.app-titlebar-icon`
+  SVG logo is hidden when running inside the Mac wrapper via an injected `documentStart`
+  stylesheet. With `.fullSizeContentView` (added in v1.5.0) the icon appeared right next
+  to the close button. The rest of the web title bar is unaffected. Closes #59.
+
 ## [v1.5.0] — 2026-04-25
 
 ### Added

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -265,6 +265,23 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         )
         config.userContentController.addUserScript(trafficLightScript)
 
+        // Fix #59: hide the web app's .app-titlebar-icon (SVG logo) when running in the
+        // Mac wrapper. With .fullSizeContentView the icon sits right next to the traffic
+        // lights and overlaps the close button. The window title and other title bar
+        // controls are unaffected.
+        let hideIconScript = WKUserScript(
+            source: """
+                (function() {
+                    const s = document.createElement('style');
+                    s.textContent = '.app-titlebar-icon { display: none !important; }';
+                    (document.head || document.documentElement).appendChild(s);
+                })();
+                """,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(hideIconScript)
+
         contentView.addSubview(webView)
 
         // Only add status bar in SSH mode


### PR DESCRIPTION
## Summary

Hotfix for the icon overlap introduced by v1.5.0's `.fullSizeContentView` change.

## Problem

The web app's `.app-titlebar` has a small SVG Hermes logo (`.app-titlebar-icon`) at the far left. Before v1.5.0 this sat below the native title bar. After v1.5.0 the content view extends under the title bar, so the icon renders right next to the traffic lights — overlapping the ✕ close button.

## Fix

One `WKUserScript` injected at `documentStart` that appends a `<style>` element hiding `.app-titlebar-icon` inside the Mac wrapper. The rest of the title bar (title text, connection badge, controls) is completely unaffected. No change to the web UI is needed.

```swift
let hideIconScript = WKUserScript(
    source: """
        (function() {
            const s = document.createElement('style');
            s.textContent = '.app-titlebar-icon { display: none !important; }';
            (document.head || document.documentElement).appendChild(s);
        })();
        """,
    injectionTime: .atDocumentStart,
    forMainFrameOnly: true
)
config.userContentController.addUserScript(hideIconScript)
```

## Pre-merge checklist

- [ ] **Mac agent build + visual verification:**

```bash
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout fix-v1.5.1-titlebar-icon && git pull --rebase

swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1
open "Hermes Agent.app"
# Verify: icon is gone from title bar, traffic lights unobstructed, title text still present
```

- [ ] Independent review from nesquena account

Closes #59
