### PR TITLE
fix: v1.5.2 — visibility:hidden keeps title centered (display:none broke layout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.5.2] — 2026-04-25
+
+### Fixed
+- **Title bar text re-centered** — v1.5.1 hid the `.app-titlebar-icon` with `display: none`,
+  which collapsed its layout space and shifted the title text left. Changed to
+  `visibility: hidden` so the icon is invisible but still occupies its flex slot, keeping
+  the title centered as intended. Closes #61.
+
 ## [v1.5.1] — 2026-04-25
 
 ### Fixed

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -273,7 +273,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             source: """
                 (function() {
                     const s = document.createElement('style');
-                    s.textContent = '.app-titlebar-icon { display: none !important; }';
+                    s.textContent = '.app-titlebar-icon { visibility: hidden !important; }';
                     (document.head || document.documentElement).appendChild(s);
                 })();
                 """,


### PR DESCRIPTION
## Summary

One-line followup to v1.5.1. Changes `display: none` → `visibility: hidden` on `.app-titlebar-icon`.

## Problem

v1.5.1 hid the icon with `display: none !important`, which removed it from the flex layout entirely. The title text was centered between the icon (left) and controls (right) — with the icon gone from layout, the title shifted left.

## Fix

`visibility: hidden` renders the element as invisible but preserves its flex slot. The title stays centered exactly as intended. Icon: gone. Layout: intact.

```diff
- s.textContent = '.app-titlebar-icon { display: none !important; }';
+ s.textContent = '.app-titlebar-icon { visibility: hidden !important; }';
```

## Pre-merge checklist

- [ ] **Mac agent build + visual verification:**

```bash
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || true
git fetch origin && git checkout fix-v1.5.2-titlebar-icon-visibility && git pull --rebase

swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1
open "Hermes Agent.app"
# Verify: icon invisible, title centered, traffic lights unobstructed
```

- [ ] Independent review from nesquena account

Closes #61
