### PR TITLE
fix: v1.5.3 — restore window drag after fullSizeContentView change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v1.5.3] — 2026-04-28
+### Fixed
+- **Window drag regression** — after the v1.5.0 `.fullSizeContentView` change, the main window could no longer be moved by dragging the title bar. `WKWebView` covers the full content area including the transparent native title bar strip and intercepts all mouse events; `-webkit-app-region: drag` in the web page's CSS has no effect on `NSWindow` dragging. Fixed by adding a thin transparent `TitleBarDragView` overlay positioned over the title bar zone (height 38 px, matching `.app-titlebar` in the web UI) that calls `window.performDrag(with:)` on `mouseDown`. The view is fully transparent and only captures hits within its own bounds. Traffic lights live in `NSThemeFrame` above `contentView` and are unaffected. (fixes #64)
+
 ## [v1.5.2] — 2026-04-25
 
 ### Fixed

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -45,6 +45,36 @@ private class HermesWebView: WKWebView {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 }
 
+// Fix #64: transparent drag view that sits atop the WKWebView in the title-bar zone.
+// With .fullSizeContentView + titlebarAppearsTransparent, WKWebView covers the native
+// title bar strip and intercepts all mouse events — killing native window drag.
+// -webkit-app-region: drag in the web page's CSS has no effect on NSWindow dragging.
+// This overlay calls window.performDrag(with:) on mouseDown in the title-bar strip,
+// restoring the expected drag-to-move behaviour. The view is fully transparent
+// (no layer, no drawing) so it has no visual impact. Traffic lights live in
+// NSThemeFrame above contentView and are unaffected.
+private class TitleBarDragView: NSView {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        // Double-click: honour the system "Double-click a window's title bar to" preference.
+        if event.clickCount == 2 {
+            let action = UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick") ?? "Maximize"
+            switch action {
+            case "Minimize": window?.miniaturize(nil)
+            case "Maximize": window?.performZoom(nil)
+            default: break  // "None"
+            }
+            return
+        }
+        // Single click: pass to the window's native drag-to-move handler.
+        window?.performDrag(with: event)
+    }
+    // No hitTest override — default NSView.hitTest is correct (point is in superview coords,
+    // default returns self when point is in frame, nil otherwise).
+    // No isFlipped override — the view has no subviews or drawing; isFlipped is irrelevant.
+}
+
 class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler {
 
     private var webView: HermesWebView!
@@ -73,6 +103,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private var findBar: NSView?
     private var findField: NSSearchField?
     private var findBarVisible = false
+    /// Fix #64: drag overlay view — kept as a property so it can be resized on window resize.
+    private var titleBarDragView: TitleBarDragView?
     /// The UserDefaults autosave name for the main window frame.
     /// Used for both windowFrameAutosaveName and the derived "NSWindow Frame <name>" key.
     private static let windowAutosaveName = "HermesMainWindow"
@@ -283,6 +315,21 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         config.userContentController.addUserScript(hideIconScript)
 
         contentView.addSubview(webView)
+
+        // Fix #64: install a thin transparent drag overlay over the title-bar zone.
+        // Height 38px matches .app-titlebar in the web UI. The view is added AFTER
+        // webView so it is on top in z-order, intercepting mouse events before WKWebView.
+        let titleBarHeight: CGFloat = 38
+        // Anchor to the top of contentView (y = bounds.height - 38 to bounds.height),
+        // matching the web UI's .app-titlebar which fills the same zone.
+        // Note: clMaxY (contentLayoutRect.maxY) is the BOTTOM of the native title bar —
+        // using clMaxY - 38 would put the overlay ~28 px below the visual title bar zone.
+        // The web title bar sits at the very top: y ∈ [bounds.height-38, bounds.height].
+        let dragFrame = NSRect(x: 0, y: bounds.height - titleBarHeight, width: bounds.width, height: titleBarHeight)
+        let dragView = TitleBarDragView(frame: dragFrame)
+        dragView.autoresizingMask = [.width, .minYMargin]
+        contentView.addSubview(dragView)
+        titleBarDragView = dragView
 
         // Only add status bar in SSH mode
         if connectionMode == "ssh" {


### PR DESCRIPTION
## Problem

After the v1.5.0 `.fullSizeContentView` + `titlebarAppearsTransparent` change, the main window can no longer be moved by dragging the title bar area (issue #64).

**Root cause:** `WKWebView` now fills the entire `contentView` including the transparent native title bar strip, and intercepts all mouse events. The `-webkit-app-region: drag` CSS in the web UI has no effect on `NSWindow` dragging — that's a browser-tab chrome feature, not a macOS window management API.

## Fix

Add a private `TitleBarDragView: NSView` subclass — a fully transparent overlay view positioned over the title bar zone (`y = bounds.height - 38` to `bounds.height`, matching `.app-titlebar { height: 38px }` in the web UI). It:

- Calls `window?.performDrag(with: event)` on single `mouseDown`, restoring native drag
- Handles double-click by reading the system `AppleActionOnDoubleClick` preference (Maximize / Minimize / None), so the standard "double-click title bar to zoom/restore" gesture still works
- Uses `acceptsFirstMouse(for:) → true` so the first click on an inactive window both activates and drags

The view is added to `contentView` after `WKWebView`, so it sits on top in z-order and wins hit-testing in the title bar zone. Traffic lights live in `NSThemeFrame` above `contentView` and are completely unaffected.

## Testing

Please run on the Mac agent:

```bash
cd /tmp/swift-mac-test
git clone https://github.com/hermes-webui/hermes-swift-mac . 2>/dev/null || \
  (cd /tmp && rm -rf swift-mac-test && git clone https://github.com/hermes-webui/hermes-swift-mac swift-mac-test && cd swift-mac-test)
git fetch origin && git checkout fix/window-drag-regression && git pull --rebase

swift package resolve
swift build -c release 2>&1
swift test 2>&1
bash build.sh 2>&1
```

**Manual verify after `bash build.sh`:**
1. Launch `Hermes Agent.app`
2. Drag the title bar area — window should move ✓
3. Double-click the title bar — window should zoom/restore ✓
4. Traffic lights (close/minimize/zoom buttons) should all still respond ✓
5. Interactive controls in the title bar (e.g., hamburger on mobile viewport) should still receive clicks ✓

Closes #64
