### PR TITLE
fix: intercept WKWebView downloads with NSSavePanel instead of render…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.5.4] — 2026-05-02
+
+### Fixed
+- **Download links now save instead of rendering raw content** — clicking a download link in the web UI loaded the raw response data into the WKWebView window instead of prompting for a save location. The `decidePolicyFor navigationResponse` handler now intercepts responses whose `Content-Disposition` header begins with `attachment` (case-insensitive) **or** whose MIME type WebKit can't render, and hands them off to `WKDownload`. The new `WKDownloadDelegate` extension presents an `NSSavePanel` pre-filled with the server's suggested filename, runs as a sheet on the main window, and surfaces failures via a sheet alert. Closes the gap where attachments from the chat UI (file exports, downloads from previous sessions, etc.) had no way to be saved. (#66, thanks @redsparklabs)
+
 ## [v1.5.3] — 2026-04-28
 ### Fixed
 - **Window drag regression** — after the v1.5.0 `.fullSizeContentView` change, the main window could no longer be moved by dragging the title bar. `WKWebView` covers the full content area including the transparent native title bar strip and intercepts all mouse events; `-webkit-app-region: drag` in the web page's CSS has no effect on `NSWindow` dragging. Fixed by adding a thin transparent `TitleBarDragView` overlay positioned over the title bar zone (height 38 px, matching `.app-titlebar` in the web UI) that calls `window.performDrag(with:)` on `mouseDown`. The view is fully transparent and only captures hits within its own bounds. Traffic lights live in `NSThemeFrame` above `contentView` and are unaffected. (fixes #64)

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -659,16 +659,25 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
-        if let httpResponse = navigationResponse.response as? HTTPURLResponse,
-            httpResponse.statusCode >= 500
-        {
-            decisionHandler(.cancel)
-            guard !didReportNavigationFailure else { return }
-            didReportNavigationFailure = true
-            onNavigationFailed?()
-        } else {
-            decisionHandler(.allow)
+        if let httpResponse = navigationResponse.response as? HTTPURLResponse {
+            if httpResponse.statusCode >= 500 {
+                decisionHandler(.cancel)
+                guard !didReportNavigationFailure else { return }
+                didReportNavigationFailure = true
+                onNavigationFailed?()
+                return
+            }
+            let disposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition") ?? ""
+            if disposition.lowercased().hasPrefix("attachment") || !navigationResponse.canShowMIMEType {
+                decisionHandler(.download)
+                return
+            }
         }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
+        download.delegate = self
     }
 
     // MARK: - File upload
@@ -922,6 +931,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
+    // MARK: - Download (WKDownloadDelegate wiring)
+
     // MARK: - Microphone / camera permissions
 
     func webView(
@@ -955,6 +966,39 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                     NSWorkspace.shared.open(url)
                 }
             }
+        }
+    }
+}
+
+// MARK: - WKDownloadDelegate
+
+extension BrowserWindowController: WKDownloadDelegate {
+    func download(
+        _ download: WKDownload,
+        decideDestinationUsing response: URLResponse,
+        suggestedFilename: String,
+        completionHandler: @escaping (URL?) -> Void
+    ) {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = suggestedFilename
+        guard let win = window else {
+            completionHandler(nil)
+            return
+        }
+        panel.beginSheetModal(for: win) { result in
+            completionHandler(result == .OK ? panel.url : nil)
+        }
+    }
+
+    func downloadDidFinish(_ download: WKDownload) {}
+
+    func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+        DispatchQueue.main.async { [weak self] in
+            guard let win = self?.window else { return }
+            let alert = NSAlert()
+            alert.messageText = "Download Failed"
+            alert.informativeText = error.localizedDescription
+            alert.beginSheetModal(for: win)
         }
     }
 }

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -931,8 +931,6 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         webView.evaluateJavaScript(js, completionHandler: nil)
     }
 
-    // MARK: - Download (WKDownloadDelegate wiring)
-
     // MARK: - Microphone / camera permissions
 
     func webView(


### PR DESCRIPTION
…ing raw content

WKWebView renders responses inline by default — clicking a download link loaded raw data into the window instead of prompting for a save location.

Intercept downloads in decidePolicyFor navigationResponse by checking the Content-Disposition: attachment header and canShowMIMEType. Hand off to WKDownloadDelegate, which presents NSSavePanel pre-filled with the server-suggested filename. Download failures surface as a sheet alert.