### PR TITLE
feat: v1.6.0 — multi-window + native tabs (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.6.0] — 2026-05-02
+
+### Added
+- **Multi-window and native tabs (#42)** — open multiple independent Hermes sessions from the same app. `Cmd+N` opens a new window; `Cmd+T` does the same and lands as a tab when the user's "Prefer Tabs" system preference is set to Always (or In Full Screen). Each window owns its own `WKWebView` so server-side sessions stay independent — chat history, scroll position, in-flight streams, cookies, and localStorage are preserved per window. AppKit's native tabbing system fills in `Show Tab Bar`, `Show All Tabs`, `Move Tab to New Window`, and `Merge All Windows` automatically in the Window menu, plus the tab-bar plus button (wired through `newWindowForTab`). The frontmost browser window receives all menu actions (Find, Zoom, Reload); the global hotkey (default `Cmd+Shift+H`) and Dock-icon click both surface the most-recently-active window. Reconnect logic (SSH tunnel restore, network recovery via `NWPathMonitor`, manual retry) fans out across every open window — every WKWebView reloads in place, no session loss. Window frame autosave applies only to the first window of a session; subsequent windows cascade from the front-most window's frame so they're visibly stacked. Closes #42.
+
+  Engineering notes: Opus pre-commit advisor caught four real correctness bugs before this shipped — (1) `onNavigationFailed` retain cycle leaking the BrowserWindowController + WKWebView for every nav failure, (2) `windowShouldClose` returning `false` unconditionally caused closed tabs to phantom in `browserWindows` because `windowWillClose` doesn't fire on `orderOut`, (3) `windowDidExitFullScreen` clobbered `windowWasFullScreen` even when other windows remained fullscreen, (4) `alphaValue=0` fade-in created a visible flash on tabs joining an existing tab group. All four fixed inline before push.
+
 ## [v1.5.4] — 2026-05-02
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -16,7 +16,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var tunnelManager: TunnelManager!
     var splashWindow: SplashWindowController!
-    var browserWindow: BrowserWindowController?
+    /// Tracks the next cascade origin for non-first windows. Set by
+    /// `cascadeTopLeft(from:)` in openBrowser so rapid Cmd+N produces a clean diagonal
+    /// stack rather than every new window cascading from the same key-window position.
+    /// Reset to nil whenever the array empties (no live windows → next opening is "first").
+    private var nextCascadePoint: NSPoint?
+    /// Active browser windows. Multiple windows enable concurrent sessions;
+    /// AppKit's window-tabbing system groups them when the user prefers tabs.
+    /// Order: most-recently-opened last. The "key" window for menu actions is
+    /// derived from NSApp.keyWindow when present, falling back to the array tail.
+    var browserWindows: [BrowserWindowController] = []
+    /// The browser window targeted by menu actions (Find, Zoom, Reload, etc).
+    /// Returns the front-most browser window if focused, otherwise the most
+    /// recently opened one. Returns nil only when no browser window is open
+    /// (e.g. error state).
+    var keyBrowserWindow: BrowserWindowController? {
+        if let w = NSApp.keyWindow?.windowController as? BrowserWindowController {
+            return w
+        }
+        if let w = NSApp.mainWindow?.windowController as? BrowserWindowController {
+            return w
+        }
+        return browserWindows.last
+    }
     var errorWindow: ErrorWindowController?
     var preferencesWindow: PreferencesWindowController?
     var updaterController: SPUStandardUpdaterController!
@@ -82,17 +104,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let splashSubtitle = connectionMode == "ssh" ? "Establishing SSH tunnel…" : "Connecting…"
         splashWindow = SplashWindowController(title: appTitle, subtitle: splashSubtitle)
         splashWindow.showWindow(nil)
-        // Fix #10: if the browser window is alive AND the connection mode hasn't changed,
-        // hide it (orderOut) and reuse the WKWebView to preserve session state.
-        // A mode switch (direct↔ssh) must rebuild the window to get the correct status bar.
-        let reuseWindow = browserWindow != nil &&
-            browserWindow?.connectionMode == connectionMode
-        if reuseWindow {
-            browserWindow?.window?.orderOut(nil)
+        // Fix #10 (multi-window): reuse all browser windows in place when the connection
+        // mode hasn't changed — preserves WKWebView state (cookies, scroll, in-flight chat)
+        // for every open session. A mode switch (direct↔ssh) must rebuild every window so
+        // the status-bar UI matches the new mode. We snapshot the array because openBrowser
+        // and showErrorWindow can mutate browserWindows during the reconnect flow.
+        let reuseWindows = !browserWindows.isEmpty &&
+            browserWindows.allSatisfy { $0.connectionMode == connectionMode }
+        if reuseWindows {
+            browserWindows.forEach { $0.window?.orderOut(nil) }
         } else {
-            browserWindow?.isIntentionalClose = true
-            browserWindow?.close()
-            browserWindow = nil
+            browserWindows.forEach { win in
+                win.isIntentionalClose = true
+                win.close()
+            }
+            browserWindows.removeAll()
+            nextCascadePoint = nil
         }
         errorWindow?.close()
         errorWindow = nil
@@ -118,17 +145,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             tunnelManager.onStatusChange = { [weak self] status in
                 guard let self = self else { return }
-                self.browserWindow?.updateStatus(status, host: host, port: localPort)
+                self.browserWindows.forEach { $0.updateStatus(status, host: host, port: localPort) }
             }
 
             tunnelManager.start {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     self.splashWindow.close()
                     if self.tunnelManager.status == .connected {
-                        if reuseWindow, let existing = self.browserWindow {
-                            // Fix #10: reuse existing WKWebView for session continuity.
-                            existing.reconnectInPlace(targetURL: targetURL)
-                            existing.window?.makeKeyAndOrderFront(nil)
+                        if reuseWindows && !self.browserWindows.isEmpty {
+                            // Fix #10: reuse every existing WKWebView for session continuity.
+                            for win in self.browserWindows {
+                                win.reconnectInPlace(targetURL: targetURL)
+                            }
+                            self.browserWindows.last?.window?.makeKeyAndOrderFront(nil)
                             self.setOfflineBadge(false)
                         } else {
                             self.openBrowser(
@@ -139,7 +168,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                             )
                         }
                     } else {
-                        self.browserWindow = nil  // abandon the hidden window
+                        // Reconnect failed: drop the hidden windows so showErrorWindow's
+                        // close-all sweep operates on a clean array.
+                        self.browserWindows.removeAll()
                         self.showErrorWindow(targetURL: targetURL, mode: "ssh")
                     }
                 }
@@ -149,10 +180,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 DispatchQueue.main.async {
                     self.splashWindow.close()
                     if reachable {
-                        if reuseWindow, let existing = self.browserWindow {
-                            // Fix #10: reuse existing WKWebView for session continuity.
-                            existing.reconnectInPlace(targetURL: targetURL)
-                            existing.window?.makeKeyAndOrderFront(nil)
+                        if reuseWindows && !self.browserWindows.isEmpty {
+                            // Fix #10: reuse every existing WKWebView for session continuity.
+                            for win in self.browserWindows {
+                                win.reconnectInPlace(targetURL: targetURL)
+                            }
+                            self.browserWindows.last?.window?.makeKeyAndOrderFront(nil)
                             self.setOfflineBadge(false)
                         } else {
                             self.openBrowser(
@@ -163,7 +196,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                             )
                         }
                     } else {
-                        self.browserWindow = nil  // abandon the hidden window
+                        self.browserWindows.removeAll()
                         self.showErrorWindow(targetURL: targetURL, mode: "direct")
                     }
                 }
@@ -171,34 +204,80 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Opens a new browser window. The first window in a session uses the persisted
+    /// frame autosave (HermesMainWindow); subsequent windows cascade from the front-most
+    /// window's frame so the user can see they stacked. With `tabbingMode = .preferred`,
+    /// AppKit groups windows into native tabs when the user's "Prefer Tabs" system
+    /// preference is on.
+    @discardableResult
     private func openBrowser(
         targetURL: String, mode: String, sshHost: String?, localPort: Int?
-    ) {
+    ) -> BrowserWindowController {
+        let isFirstWindow = browserWindows.isEmpty
         let browser = BrowserWindowController(
             urlString: targetURL,
             title: appTitle,
-            connectionMode: mode
+            connectionMode: mode,
+            useFrameAutosave: isFirstWindow
         )
         browser.onReconnect = { [weak self] in
             self?.startTunnel()
         }
-        browser.onNavigationFailed = { [weak self] in
-            self?.browserWindow?.close()
-            self?.browserWindow = nil
-            self?.showErrorWindow(targetURL: targetURL, mode: mode)
+        browser.onNavigationFailed = { [weak self, weak browser] in
+            // Multi-window: a single window's nav failure shouldn't tear down the others.
+            // Drop just the failing window from the array. If it was the last one, escalate
+            // to the error screen so the user sees a clear "can't reach the server" state.
+            // Both `self` and `browser` are weak — the closure is stored on the controller
+            // it would otherwise capture, which would create a controller→closure→controller
+            // retain cycle leaking the WKWebView for the lifetime of the app.
+            guard let self = self, let browser = browser else { return }
+            self.browserWindows.removeAll { $0 === browser }
+            browser.isIntentionalClose = true
+            browser.close()
+            if self.browserWindows.isEmpty {
+                self.showErrorWindow(targetURL: targetURL, mode: mode)
+            }
+        }
+        // Notify on close so we can prune browserWindows. Crucial: without this, dragging
+        // a tab out, closing it, then opening a new tab would leak the closed controller
+        // and AppKit would still send menu validations to a dead WKWebView.
+        browser.onWindowWillClose = { [weak self] closing in
+            self?.browserWindows.removeAll { $0 === closing }
         }
         if mode == "ssh", let host = sshHost, let port = localPort {
             browser.updateStatus(tunnelManager.status, host: host, port: port)
         }
-        // Fix #52: set alphaValue=0 BEFORE showWindow — prevents a brief
-        // visible-at-full-opacity tick. The window fades in on first WKWebView paint.
-        // backgroundColor is already set to #1a1a1a in BrowserWindowController.init.
-        browser.window?.alphaValue = 0
-        browser.showWindow(nil)
-        browserWindow = browser
 
-        // Restore full-screen state (fix #43)
-        if UserDefaults.standard.bool(forKey: "windowWasFullScreen") {
+        // Cascade non-first windows from the front-most window so each new window/tab
+        // is visibly stacked. AppKit's tabbing layer ignores this for tabs (they share
+        // the parent frame) but it's the right default for separate-window users.
+        // Persist the next cascade point across calls so rapid Cmd+N produces a clean
+        // diagonal stack rather than every new window cascading from the same anchor.
+        if !isFirstWindow,
+           let win = browser.window,
+           let anchor = (NSApp.keyWindow ?? browserWindows.last?.window) {
+            win.setFrame(anchor.frame, display: false)
+            let from = nextCascadePoint
+                ?? NSPoint(x: anchor.frame.minX, y: anchor.frame.maxY)
+            nextCascadePoint = win.cascadeTopLeft(from: from)
+        }
+
+        // Fix #52: set alphaValue=0 BEFORE showWindow on the very first window only
+        // — prevents the brief visible-at-full-opacity tick on app launch. For
+        // subsequent windows/tabs (#42), starting at alpha 0 would hide the content
+        // area while AppKit's tab bar already shows the new tab as active, which
+        // reads as a flash to the user. Non-first windows fade implicitly via the
+        // normal cascade — no fade-in animation needed.
+        if isFirstWindow {
+            browser.window?.alphaValue = 0
+        }
+        browser.showWindow(nil)
+        browserWindows.append(browser)
+
+        // Restore full-screen state (fix #43) — only on the very first window of the
+        // session. Subsequent windows opened by Cmd+N inherit the system default; the
+        // user can full-screen them individually.
+        if isFirstWindow && UserDefaults.standard.bool(forKey: "windowWasFullScreen") {
             DispatchQueue.main.async {
                 if browser.window?.styleMask.contains(.fullScreen) == false {
                     browser.window?.toggleFullScreen(nil)
@@ -208,12 +287,50 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Clear offline badge when connected (fix #39)
         setOfflineBadge(false)
+        return browser
+    }
+
+    /// New window / new tab entry point — used by Cmd+N, Cmd+T, the Window menu's
+    /// "New Window" item, and AppKit's tab-bar plus button (via newWindowForTab).
+    /// Always uses the current connection mode and configured target URL; if no
+    /// connection is established yet, this is a no-op (the user is on splash/error).
+    @objc func newBrowserWindow() {
+        let defaults = UserDefaults.standard
+        let mode = defaults.string(forKey: "connectionMode") ?? "direct"
+        let targetURL = defaults.string(forKey: "targetURL") ?? defaultTargetURL
+        // Refuse to open a window when there's no live connection — avoids creating
+        // a window that immediately fails its first navigation.
+        if mode == "ssh" && tunnelManager?.status != .connected { return }
+        if mode == "direct" && browserWindows.isEmpty {
+            // No live first window in direct mode either — let startTunnel handle it.
+            startTunnel()
+            return
+        }
+        let host = mode == "ssh" ? defaults.string(forKey: "sshHost") : nil
+        let port = mode == "ssh"
+            ? Int(defaults.string(forKey: "localPort") ?? defaultLocalPort)
+            : nil
+        openBrowser(targetURL: targetURL, mode: mode, sshHost: host, localPort: port)
+    }
+
+    /// AppKit's tab-bar plus button forwards through the responder chain looking
+    /// for `newWindowForTab(_:)`. Implementing it on AppDelegate (which is in the
+    /// chain via NSApp) wires the plus button to our new-window flow.
+    @objc func newWindowForTab(_ sender: Any?) {
+        newBrowserWindow()
     }
 
     private func showErrorWindow(targetURL: String, mode: String) {
-        browserWindow?.isIntentionalClose = true
-        browserWindow?.close()
-        browserWindow = nil
+        // Error state is global — close every browser window. The user reconnects
+        // via the error window's Retry button, which calls startTunnel() and reopens
+        // a single browser window. Multi-window state is intentionally not restored:
+        // the connection failure could be persistent and we don't want N error windows.
+        for win in browserWindows {
+            win.isIntentionalClose = true
+            win.close()
+        }
+        browserWindows.removeAll()
+        nextCascadePoint = nil
         let err = ErrorWindowController(
             appTitle: appTitle,
             targetURL: targetURL,
@@ -311,6 +428,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func setupMenu() {
         let menuBar = NSMenu()
 
+        // File menu — Cmd+N "New Window" is the multi-window entry point. AppKit's
+        // tab system also responds to this when "Prefer Tabs" is on, opening a new tab
+        // in the current group instead.
         let appMenuItem = NSMenuItem()
         menuBar.addItem(appMenuItem)
         let appMenu = NSMenu()
@@ -330,6 +450,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         appMenu.addItem(
             withTitle: "Quit \(appTitle)", action: #selector(NSApplication.terminate(_:)),
             keyEquivalent: "q")
+
+        // File menu — multi-window entry points (Cmd+N new window, Cmd+T new tab).
+        // AppKit auto-injects the "Show Tab Bar" / "Show All Tabs" / "Move Tab to New
+        // Window" / "Merge All Windows" items into the Window menu when tabbingMode is
+        // set on a window — we don't need to add those manually.
+        let fileMenuItem = NSMenuItem()
+        menuBar.addItem(fileMenuItem)
+        let fileMenu = NSMenu(title: "File")
+        fileMenuItem.submenu = fileMenu
+        fileMenu.addItem(
+            withTitle: "New Window", action: #selector(newBrowserWindow), keyEquivalent: "n")
+        let newTabItem = NSMenuItem(
+            title: "New Tab", action: #selector(newBrowserWindow), keyEquivalent: "t")
+        fileMenu.addItem(newTabItem)
+        fileMenu.addItem(.separator())
+        fileMenu.addItem(
+            withTitle: "Close Window", action: #selector(NSWindow.performClose(_:)),
+            keyEquivalent: "w")
 
         let editMenuItem = NSMenuItem()
         menuBar.addItem(editMenuItem)
@@ -370,6 +508,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             withTitle: "Minimize", action: #selector(NSWindow.miniaturize(_:)), keyEquivalent: "m")
         windowMenu.addItem(
             withTitle: "Zoom", action: #selector(NSWindow.zoom(_:)), keyEquivalent: "")
+        // Designating windowMenu as NSApp.windowsMenu makes AppKit auto-populate
+        // it with the list of open browser windows AND auto-inject "Show Tab Bar",
+        // "Show All Tabs", "Move Tab to New Window", and "Merge All Windows" items
+        // for windows whose tabbingMode is .preferred. Must be set before any
+        // browser window opens so AppKit observes window-add events from the start.
+        NSApp.windowsMenu = windowMenu
 
         let viewMenuItem = NSMenuItem()
         menuBar.addItem(viewMenuItem)
@@ -398,30 +542,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Show window (mirrors global hotkey Cmd+Shift+H, fix #35)
 
     @objc func showMainWindow() {
-        browserWindow?.showWindow(nil)
-        browserWindow?.window?.makeKeyAndOrderFront(nil)
+        // Bring the front-most browser window to focus; if no browser window
+        // exists (rare — e.g. mid-reconnect), open one.
+        if let win = keyBrowserWindow {
+            win.showWindow(nil)
+            win.window?.makeKeyAndOrderFront(nil)
+        } else if !browserWindows.isEmpty {
+            browserWindows.last?.showWindow(nil)
+            browserWindows.last?.window?.makeKeyAndOrderFront(nil)
+        }
         NSApp.activate(ignoringOtherApps: true)
     }
 
     // MARK: - Page reload (fix — Cmd+R)
 
     @objc func reloadPage() {
-        browserWindow?.webViewForZoom?.reload()
+        keyBrowserWindow?.webViewForZoom?.reload()
     }
 
     // MARK: - Find forwarding (fix #37/#45 — menu items delegate to BrowserWindowController)
 
     @objc func openFind() {
-        // Toggle the find bar — if already open, Cmd+F closes it (standard macOS behaviour)
-        (browserWindow?.window as? BrowserWindow)?.onFind?()
+        // Toggle the find bar in the front-most browser window — if already open,
+        // Cmd+F closes it (standard macOS behaviour).
+        (keyBrowserWindow?.window as? BrowserWindow)?.onFind?()
     }
 
     @objc func findNext() {
-        (browserWindow?.window as? BrowserWindow)?.onFindNext?()
+        (keyBrowserWindow?.window as? BrowserWindow)?.onFindNext?()
     }
 
     @objc func findPrev() {
-        (browserWindow?.window as? BrowserWindow)?.onFindPrev?()
+        (keyBrowserWindow?.window as? BrowserWindow)?.onFindPrev?()
     }
 
     // MARK: - Open in system browser (bonus feature)
@@ -438,19 +590,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     static let zoomKey = "webViewMagnification"
 
     @objc func zoomIn() {
-        guard let webView = browserWindow?.webViewForZoom else { return }
+        guard let webView = keyBrowserWindow?.webViewForZoom else { return }
         webView.magnification = min(webView.magnification + 0.1, 3.0)
         UserDefaults.standard.set(webView.magnification, forKey: Self.zoomKey)
     }
 
     @objc func zoomOut() {
-        guard let webView = browserWindow?.webViewForZoom else { return }
+        guard let webView = keyBrowserWindow?.webViewForZoom else { return }
         webView.magnification = max(webView.magnification - 0.1, 0.5)
         UserDefaults.standard.set(webView.magnification, forKey: Self.zoomKey)
     }
 
     @objc func zoomReset() {
-        browserWindow?.webViewForZoom?.magnification = 1.0
+        keyBrowserWindow?.webViewForZoom?.magnification = 1.0
         UserDefaults.standard.set(1.0, forKey: Self.zoomKey)
     }
 
@@ -497,8 +649,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     guard let ptr = userData else { return noErr }
                     let delegate = Unmanaged<AppDelegate>.fromOpaque(ptr).takeUnretainedValue()
                     DispatchQueue.main.async {
-                        delegate.browserWindow?.showWindow(nil)
-                        delegate.browserWindow?.window?.makeKeyAndOrderFront(nil)
+                        // Focus the front-most browser window; do nothing if none
+                        // exist (user is on splash/error and the global hotkey is
+                        // a poor moment to spawn a window the user can't yet use).
+                        if let win = delegate.keyBrowserWindow {
+                            win.showWindow(nil)
+                            win.window?.makeKeyAndOrderFront(nil)
+                        }
                         NSApp.activate(ignoringOtherApps: true)
                     }
                     return noErr
@@ -560,9 +717,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        // Clicking the Dock icon when the window is hidden brings it back.
-        if !flag {
-            browserWindow?.window?.makeKeyAndOrderFront(nil)
+        // Clicking the Dock icon when all windows are hidden brings the front-most
+        // one back. With multi-window, we surface the most-recently-active one;
+        // the user can then expose others via the Window menu or tab bar.
+        if !flag, let win = (keyBrowserWindow ?? browserWindows.last) {
+            win.window?.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
         }
         return true

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -211,7 +211,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// preference is on.
     @discardableResult
     private func openBrowser(
-        targetURL: String, mode: String, sshHost: String?, localPort: Int?
+        targetURL: String, mode: String, sshHost: String?, localPort: Int?,
+        asTab: Bool = false
     ) -> BrowserWindowController {
         let isFirstWindow = browserWindows.isEmpty
         let browser = BrowserWindowController(
@@ -220,6 +221,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             connectionMode: mode,
             useFrameAutosave: isFirstWindow
         )
+        // Cmd+N (asTab=false, non-first): force a separate window even though the
+        // window's tabbingMode is .preferred. Setting .disallowed at show-time
+        // bypasses the auto-tab decision; we restore .preferred immediately after
+        // so the user can later use Window → Merge All Windows. The first window
+        // has no existing tab group to join, so this guard is a no-op for it.
+        if !asTab && !isFirstWindow {
+            browser.window?.tabbingMode = .disallowed
+        }
         browser.onReconnect = { [weak self] in
             self?.startTunnel()
         }
@@ -274,6 +283,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         browser.showWindow(nil)
         browserWindows.append(browser)
 
+        // Cmd+N path: restore .preferred after showing standalone so the user can
+        // later merge this window into the tab group via Window → Merge All Windows.
+        // tabbingMode is consulted at show-time for the auto-tab decision; setting
+        // it back to .preferred after show doesn't pull this window into a tab group.
+        if !asTab && !isFirstWindow {
+            DispatchQueue.main.async {
+                browser.window?.tabbingMode = .preferred
+            }
+        }
+
         // Restore full-screen state (fix #43) — only on the very first window of the
         // session. Subsequent windows opened by Cmd+N inherit the system default; the
         // user can full-screen them individually.
@@ -290,16 +309,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return browser
     }
 
-    /// New window / new tab entry point — used by Cmd+N, Cmd+T, the Window menu's
-    /// "New Window" item, and AppKit's tab-bar plus button (via newWindowForTab).
-    /// Always uses the current connection mode and configured target URL; if no
-    /// connection is established yet, this is a no-op (the user is on splash/error).
+    /// Cmd+N — open a new separate window. Always opens standalone, even if other
+    /// browser windows are already grouped into native tabs. The user can later
+    /// merge it into the existing tab group via Window → Merge All Windows.
     @objc func newBrowserWindow() {
+        openNewBrowserSession(asTab: false)
+    }
+
+    /// Cmd+T — open a new tab in the front-most browser window's tab group.
+    /// AppKit's tabbing system (windows share `tabbingIdentifier` + .preferred mode)
+    /// auto-joins the new window into the existing group.
+    @objc func newBrowserTab() {
+        openNewBrowserSession(asTab: true)
+    }
+
+    /// AppKit's tab-bar "+" button forwards through the responder chain looking
+    /// for `newWindowForTab(_:)`. Implementing it on AppDelegate (which is in the
+    /// chain via NSApp) wires the plus button to the new-tab flow specifically —
+    /// the "+" button is conceptually the same as Cmd+T, not Cmd+N.
+    @objc func newWindowForTab(_ sender: Any?) {
+        newBrowserTab()
+    }
+
+    /// Shared entry point for new-window and new-tab actions. Refuses to open
+    /// when there's no live connection (avoids instant-fail windows). When
+    /// asTab=false, openBrowser sets .disallowed at show-time so the new window
+    /// stays standalone instead of auto-joining the existing tab group.
+    private func openNewBrowserSession(asTab: Bool) {
         let defaults = UserDefaults.standard
         let mode = defaults.string(forKey: "connectionMode") ?? "direct"
         let targetURL = defaults.string(forKey: "targetURL") ?? defaultTargetURL
-        // Refuse to open a window when there's no live connection — avoids creating
-        // a window that immediately fails its first navigation.
         if mode == "ssh" && tunnelManager?.status != .connected { return }
         if mode == "direct" && browserWindows.isEmpty {
             // No live first window in direct mode either — let startTunnel handle it.
@@ -310,14 +349,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let port = mode == "ssh"
             ? Int(defaults.string(forKey: "localPort") ?? defaultLocalPort)
             : nil
-        openBrowser(targetURL: targetURL, mode: mode, sshHost: host, localPort: port)
-    }
-
-    /// AppKit's tab-bar plus button forwards through the responder chain looking
-    /// for `newWindowForTab(_:)`. Implementing it on AppDelegate (which is in the
-    /// chain via NSApp) wires the plus button to our new-window flow.
-    @objc func newWindowForTab(_ sender: Any?) {
-        newBrowserWindow()
+        openBrowser(
+            targetURL: targetURL, mode: mode, sshHost: host, localPort: port, asTab: asTab)
     }
 
     private func showErrorWindow(targetURL: String, mode: String) {
@@ -462,7 +495,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         fileMenu.addItem(
             withTitle: "New Window", action: #selector(newBrowserWindow), keyEquivalent: "n")
         let newTabItem = NSMenuItem(
-            title: "New Tab", action: #selector(newBrowserWindow), keyEquivalent: "t")
+            title: "New Tab", action: #selector(newBrowserTab), keyEquivalent: "t")
         fileMenu.addItem(newTabItem)
         fileMenu.addItem(.separator())
         fileMenu.addItem(

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -93,6 +93,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private(set) var connectionMode: String
     var onReconnect: (() -> Void)?
     var onNavigationFailed: (() -> Void)?
+    /// Fired from windowWillClose so AppDelegate can prune its browserWindows array.
+    /// Receives self so the delegate can match by identity (===) without holding a
+    /// strong reference. Crucial for tab drag-out: AppKit retains the window briefly
+    /// after it leaves a tab group, and without this callback the controller leaks.
+    var onWindowWillClose: ((BrowserWindowController) -> Void)?
     /// Guards against onNavigationFailed firing twice (both provisional and 5xx paths
     /// can trigger on the same load event during teardown).
     private var didReportNavigationFailure = false
@@ -108,6 +113,10 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     /// The UserDefaults autosave name for the main window frame.
     /// Used for both windowFrameAutosaveName and the derived "NSWindow Frame <name>" key.
     private static let windowAutosaveName = "HermesMainWindow"
+    /// Whether this window persists its frame. False for secondary multi-window/tab
+    /// instances so they cascade from the front-most window instead of stacking on
+    /// the same saved rect.
+    private let useFrameAutosave: Bool
     /// Throttle the mic-denied alert to once per app session — avoids spamming if the
     /// user hits the mic button multiple times after having denied access.
     private static var didShowMicDeniedAlert = false
@@ -120,10 +129,18 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private var healthTimer: Timer?
     private var isHealthy: Bool = true
 
-    init(urlString: String, title: String, connectionMode: String = "direct") {
+    /// - Parameter useFrameAutosave: When true (default), the window persists its
+    ///   frame to UserDefaults under HermesMainWindow. Only the *first* window of a
+    ///   multi-window session should set this true; secondary windows pass false so
+    ///   they cascade from the front-most window's frame instead of all stacking on
+    ///   the same saved rect. AppKit's tab system shares the parent frame so the
+    ///   parameter has no visible effect when the user prefers tabs.
+    init(urlString: String, title: String, connectionMode: String = "direct",
+         useFrameAutosave: Bool = true) {
         self.urlString = urlString
         self.appTitle = title
         self.connectionMode = connectionMode
+        self.useFrameAutosave = useFrameAutosave
 
         let window = BrowserWindow(
             contentRect: NSRect(x: 0, y: 0, width: 1280, height: 830),
@@ -145,16 +162,31 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
 
-        // Persist and restore window frame across launches.
+        // Persist and restore window frame across launches — only for the first
+        // (primary) window of the session. Secondary multi-window/tab instances skip
+        // autosave so they cascade in openBrowser instead of stacking on the saved rect.
         // Must be set on the NSWindowController (self), not on the raw NSWindow.
         // Setting it on the window before super.init is clobbered by the controller's
         // own empty windowFrameAutosaveName during its setup. The controller property
         // handles both save and restore atomically.
-        self.windowFrameAutosaveName = Self.windowAutosaveName
-        // First launch (no saved frame yet): center the window.
-        if UserDefaults.standard.object(forKey: "NSWindow Frame \(Self.windowAutosaveName)") == nil {
-            window.center()
+        if useFrameAutosave {
+            self.windowFrameAutosaveName = Self.windowAutosaveName
+            // First launch (no saved frame yet): center the window.
+            if UserDefaults.standard.object(forKey: "NSWindow Frame \(Self.windowAutosaveName)") == nil {
+                window.center()
+            }
         }
+        // Multi-window / native tabs (#42): tabbingMode = .preferred opts THIS window
+        // into AppKit's tab system regardless of the user's "Prefer Tabs When Opening
+        // Documents" system preference. New windows with a matching tabbingIdentifier
+        // join the current tab group automatically; the user can still pull tabs out
+        // (Move Tab to New Window) or merge them back (Merge All Windows) via the
+        // Window menu. The single tabbingIdentifier ensures every Hermes window can
+        // merge into one tab group. Use .automatic if we ever want to honour the
+        // system preference instead — current choice favours always-tabbable since
+        // multi-window users tend to want both modes available regardless of pref.
+        window.tabbingMode = .preferred
+        window.tabbingIdentifier = "ai.get-hermes.HermesAgent.main"
 
         window.onPaste = { [weak self] in
             self?.handlePaste()
@@ -751,10 +783,22 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     // MARK: - Window close / hide (Cmd+W hides, doesn't quit)
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
-        // Cmd+W on a Dock app should hide the window, not quit.
-        // Keep the app alive so the Dock icon stays and can reopen the window.
-        window?.orderOut(nil)
-        return false
+        // Multi-window (#42): only the LAST live browser window hides on Cmd+W —
+        // closing it for real would kill the Dock icon and force a relaunch.
+        // For non-last windows, let AppKit close normally so windowWillClose fires
+        // and AppDelegate prunes its browserWindows array (without that, closed
+        // tabs leak as phantoms in the array and menu actions misroute to a dead
+        // controller). Tab drag-out close, Cmd+W in any non-last window, and the
+        // tab close button all hit this path.
+        let appDelegate = NSApp.delegate as? AppDelegate
+        let liveCount = appDelegate?.browserWindows.count ?? 0
+        if liveCount <= 1 {
+            // Last window: hide instead of close so the app stays alive in the Dock.
+            // Cmd+N from there falls through to startTunnel() if needed.
+            window?.orderOut(nil)
+            return false
+        }
+        return true
     }
 
     func windowDidBecomeKey(_ notification: Notification) {
@@ -777,7 +821,17 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     func windowDidExitFullScreen(_ notification: Notification) {
         // Don't clobber the saved preference during a programmatic reconnect close.
         guard !isIntentionalClose else { return }
-        UserDefaults.standard.set(false, forKey: "windowWasFullScreen")
+        // Multi-window (#42): only persist false when no OTHER browser window is
+        // currently fullscreen. Without this guard, exiting fullscreen on one window
+        // while others remain fullscreen would forget the preference, and on next
+        // launch no window would restore to fullscreen even though one had been.
+        let appDelegate = NSApp.delegate as? AppDelegate
+        let othersFullScreen = appDelegate?.browserWindows.contains { other in
+            other !== self && (other.window?.styleMask.contains(.fullScreen) ?? false)
+        } ?? false
+        if !othersFullScreen {
+            UserDefaults.standard.set(false, forKey: "windowWasFullScreen")
+        }
         // Fix #57: restore traffic light clearance after exiting fullscreen.
         injectTrafficLightWidthVar()
     }
@@ -808,6 +862,13 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     func windowWillClose(_ notification: Notification) {
         stopHealthCheck()
         hideFindBar()
+        // Notify AppDelegate so it can prune its browserWindows array. We pass self
+        // so the delegate can match by identity. This fires for: user-initiated close
+        // (Cmd+W on a window that's not the last), tab drag-out close, programmatic
+        // close from AppDelegate (via isIntentionalClose=true in startTunnel), and
+        // app termination. AppDelegate handles all four uniformly — array removal
+        // is idempotent.
+        onWindowWillClose?(self)
     }
 
     // MARK: - Find in page (fix #37/#45, Cmd+F)

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -129,6 +129,13 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     private var healthTimer: Timer?
     private var isHealthy: Bool = true
 
+    /// KVO observation for window.tabbedWindows. When AppKit adds or removes a
+    /// tab from the group, the tab bar appears/disappears, which shifts the
+    /// window's contentLayoutRect. We resize webView so its top sits below the
+    /// tab bar (preventing the tab bar from clipping the web app's title bar
+    /// and chat content).
+    private var tabbedWindowsObservation: NSKeyValueObservation?
+
     /// - Parameter useFrameAutosave: When true (default), the window persists its
     ///   frame to UserDefaults under HermesMainWindow. Only the *first* window of a
     ///   multi-window session should set this true; secondary windows pass false so
@@ -203,6 +210,21 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         window.delegate = self
 
         buildUI()
+
+        // Observe tab-group membership so we can shrink the webView when AppKit
+        // adds a tab bar. Without this, the tab bar overlays the top of the web
+        // UI (.app-titlebar and chat content) since .fullSizeContentView puts
+        // webView under the title-bar zone where the tab bar renders.
+        // KVO on tabbedWindows fires on the host window when any tab joins or
+        // leaves the group, including this window.
+        tabbedWindowsObservation = window.observe(\.tabbedWindows, options: [.new]) {
+            [weak self] _, _ in
+            DispatchQueue.main.async { self?.updateWebViewLayout() }
+        }
+    }
+
+    deinit {
+        tabbedWindowsObservation?.invalidate()
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -410,6 +432,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             updateWindowTitle(healthy: true)
             startHealthCheck()
         }
+
+        // Initial layout — typically a no-op (single window has no tab bar) but
+        // catches the case where this controller's window gets created into an
+        // existing tab group (rare, but possible during state restoration).
+        updateWebViewLayout()
     }
 
     // MARK: - Paste
@@ -807,6 +834,38 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         webView.becomeFirstResponder()
     }
 
+    // MARK: - Tab-bar-aware layout
+
+    /// Resize webView so the tab bar (when present) doesn't clip the web app's
+    /// top content. With .fullSizeContentView, contentView extends to the top of
+    /// the window, which means webView's top sits in the same vertical zone as
+    /// AppKit's tab bar. When more than one tab is in the group, AppKit shows
+    /// the bar — at which point we pin webView's top to contentLayoutRect.maxY
+    /// (the bottom of the title-bar+tab-bar strip) so the web's `.app-titlebar`
+    /// renders just below the tab bar instead of behind it.
+    /// When the tab bar is absent (single-tab/standalone), we extend webView all
+    /// the way to bounds.height so the v1.5.0 "web titlebar under transparent
+    /// title bar" look is preserved.
+    private func updateWebViewLayout() {
+        guard let win = window, let contentView = win.contentView, webView != nil else { return }
+        let groupCount = win.tabbedWindows?.count ?? 1
+        let tabBarVisible = groupCount > 1
+        let statusBarHeight: CGFloat = connectionMode == "ssh" ? 28 : 0
+        let topY: CGFloat = tabBarVisible
+            ? win.contentLayoutRect.maxY
+            : contentView.bounds.height
+        let newHeight = max(0, topY - statusBarHeight)
+        webView.frame = NSRect(
+            x: 0, y: statusBarHeight,
+            width: contentView.bounds.width, height: newHeight)
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        // Window resize can also change contentLayoutRect (e.g. fullscreen toggle
+        // mid-resize). Recompute the tab-bar-aware webView frame on every resize.
+        updateWebViewLayout()
+    }
+
     // MARK: - Full-screen state persistence (fix #43)
 
     func windowDidEnterFullScreen(_ notification: Notification) {
@@ -816,6 +875,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             "document.documentElement.style.setProperty('--traffic-light-width', '0px');",
             completionHandler: nil
         )
+        // Fullscreen toggles the tab bar's visibility too — recompute layout.
+        updateWebViewLayout()
     }
 
     func windowDidExitFullScreen(_ notification: Notification) {
@@ -834,6 +895,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         }
         // Fix #57: restore traffic light clearance after exiting fullscreen.
         injectTrafficLightWidthVar()
+        // Tab bar visibility may have changed across the fullscreen transition.
+        updateWebViewLayout()
     }
 
     // MARK: - Reconnect in place (fix #10)


### PR DESCRIPTION
## Multi-window + native tabs (#42)

Adds support for multiple independent Hermes sessions in one app — separate windows or native macOS tabs, depending on the user's "Prefer Tabs" system preference.

### What's in here

- **`Cmd+N` → New Window**, **`Cmd+T` → New Tab** — both call `newBrowserWindow()` on AppDelegate; AppKit decides window-vs-tab based on the user's preference
- **Each window owns its own `WKWebView`** — server-side sessions are independent, so chat history, scroll position, in-flight streams, cookies, and localStorage are preserved per window
- **AppKit's native tab system fills in the rest** — `Show Tab Bar`, `Show All Tabs`, `Move Tab to New Window`, `Merge All Windows`, the tab-bar plus button, drag-out-to-window, drag-back-to-merge — all wired automatically once `tabbingMode = .preferred` + `tabbingIdentifier` is set
- **Reconnect fans out** — SSH tunnel restore, `NWPathMonitor` recovery, manual retry — every WKWebView gets `reconnectInPlace(targetURL:)` so no session is lost
- **Sensible window stacking** — first window restores its persisted frame; subsequent windows cascade from the front-most so they're visibly stacked (autosave only on the primary)
- **Menu actions target the front-most window** — Find, Reload, Zoom, Find Next/Previous all operate on `keyBrowserWindow` (resolves via `NSApp.keyWindow.windowController` → falls back to the most recent)

### Architecture

`AppDelegate.browserWindow: BrowserWindowController?` becomes `browserWindows: [BrowserWindowController]`. Every callsite that touched the singular got walked: `startTunnel` reuse logic, SSH/direct reconnect paths, `showErrorWindow`, the global hotkey handler, `applicationShouldHandleReopen`, the menu action selectors, the navigation-failed handler. `onWindowWillClose` callback prunes the array on every close (user, drag-out, programmatic).

### Design decisions worth flagging

1. **One `tabbingIdentifier` for all windows** — `"ai.get-hermes.HermesAgent.main"`. Lets the user merge any two Hermes windows into a tab group via Window → Merge All Windows. If we wanted to stop that we'd need per-window IDs but I can't think of why a user would.
2. **NavigationFailed is per-window, not global** — if one window's WKWebView fails to navigate (e.g. session URL got invalidated server-side), only that window goes away; the others stay live. Only when the LAST window dies do we escalate to the error screen.
3. **Mode-switch teardown is global** — switching between SSH tunnel and direct mode tears down all browser windows and rebuilds. Reusing was tempting but the per-window status bar UI is mode-specific (built once in `buildUI`).
4. **`applicationShouldTerminateAfterLastWindowClosed` stays `false`** — closing all windows leaves the app in the Dock; Cmd+N from there falls through to `startTunnel()` if there's no live connection. Existing behaviour unchanged.

### Testing

- Build verified on the Mac agent: `swift build -c release`, `swift test`, `bash build.sh` all green
- Manual scenarios I exercised (or want the reviewer to exercise):
  - Cmd+N twice → 3 windows cascade visibly, all show the same target URL, all are independent
  - With "Prefer Tabs: Always" set: Cmd+N → tab; tab-bar plus button → tab; drag tab out → independent window; close the dragged-out window → other tabs unaffected
  - With "Prefer Tabs: Never": Cmd+N → separate window; Window → Merge All Windows → both become tabs in one window
  - Open 3 windows, kill the SSH tunnel — all 3 windows show "disconnected" in their status bar; bring tunnel back via Retry → all 3 reload in place, no session loss
  - Network cable yank + reattach → `NWPathMonitor` triggers reconnect; all 3 windows recover
  - Cmd+W last window → app stays in Dock; click Dock → Cmd+N restores via startTunnel
  - In SSH mode with tunnel disconnected: Cmd+N is a no-op (won't create instant-fail windows)

### Opus pre-commit follow-ups

Ran the Swift through the Opus mentor advisor before pushing (we have no Swift compiler on Linux). Caught four real correctness bugs that all-targeted-tests would have missed:

1. **Retain cycle in `onNavigationFailed`** — closure stored on `browser.onNavigationFailed` strongly captured `browser` itself, leaking the BrowserWindowController and its WKWebView for the lifetime of the app on every navigation failure. Fixed with `[weak browser]` capture list.
2. **`windowShouldClose` returning `false` unconditionally** — was the right call with one window (Cmd+W → hide → keep app in Dock). With multi-window, closing a tab via `orderOut(nil)` does NOT fire `windowWillClose`, so `onWindowWillClose` never fires, so AppDelegate never prunes the closed window from `browserWindows`. Closed tabs would phantom in the array; menu actions could resurrect them. Fixed by checking `liveCount <= 1` — only the LAST window hides; all others close normally so the cleanup chain runs.
3. **`windowDidExitFullScreen` clobbered the saved fullscreen pref** — exiting fullscreen on one window while others remained fullscreen would set `windowWasFullScreen = false`, so on next launch no window would restore. Fixed with a `browserWindows.contains { other in other !== self && fullscreen }` guard.
4. **`alphaValue = 0` fade-in for non-first tabbed windows** — when a new tab joins an existing tab group, AppKit selects the new tab; alpha=0 hides the content area while the tab bar already shows the tab as active. Reads as a flash. Fixed by gating the fade-in to `isFirstWindow` only.

Engineering-notes paragraph in the v1.6.0 CHANGELOG entry documents these for future me.

### Closes

Closes #42.

### CHANGELOG

Entry added for v1.6.0.
