### PR TITLE
fix: theme bridge reads `<meta name="theme-color">` first, falls back to pixel sample (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v1.6.2] — TBD
+## [v1.6.2] — 2026-05-06
 
 ### Fixed
 - **Tab-bar / title-bar strip flashes white in multi-tab sessions, and stays stuck after closing the offending tab — bug #70** — v1.6.1's theme bridge sampled the page background by walking `document.elementsFromPoint(x, y)` at three fixed viewport coordinates. Any opaque modal, lightbox, settings panel, file-tree overlay, or image preview that covered any of the three sample points and stayed visible past the 2.5 s stability gate would make the bridge fire the *overlay's* colour. With multi-tab, that one tab's overlay-derived colour was then propagated to every other window's chrome, producing the symptom Cygnus filed in #70 (white tab strip persisting until the user could refresh). The pixel-sampling architecture is fundamentally fragile against legitimate page overlays. Fix: prefer the WebUI's own `<meta name="theme-color" id="hermes-theme-color">` tag (introduced in hermes-webui v0.51.x+) as the single source of truth — it's page-controlled, overlay-resistant, and updated by `boot.js` whenever the user toggles theme or skin. The bridge falls back to the original pixel-sampling path when the meta tag is absent (older WebUI servers, raw error pages), so behavior is unchanged for self-hosters who haven't updated yet. Also adds a `MutationObserver` on the meta tag's `content` attribute so toggles propagate without waiting for the 2 s poll tick. Closes #70.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.6.2] — TBD
+
+### Fixed
+- **Tab-bar / title-bar strip flashes white in multi-tab sessions, and stays stuck after closing the offending tab — bug #70** — v1.6.1's theme bridge sampled the page background by walking `document.elementsFromPoint(x, y)` at three fixed viewport coordinates. Any opaque modal, lightbox, settings panel, file-tree overlay, or image preview that covered any of the three sample points and stayed visible past the 2.5 s stability gate would make the bridge fire the *overlay's* colour. With multi-tab, that one tab's overlay-derived colour was then propagated to every other window's chrome, producing the symptom Cygnus filed in #70 (white tab strip persisting until the user could refresh). The pixel-sampling architecture is fundamentally fragile against legitimate page overlays. Fix: prefer the WebUI's own `<meta name="theme-color" id="hermes-theme-color">` tag (introduced in hermes-webui v0.51.x+) as the single source of truth — it's page-controlled, overlay-resistant, and updated by `boot.js` whenever the user toggles theme or skin. The bridge falls back to the original pixel-sampling path when the meta tag is absent (older WebUI servers, raw error pages), so behavior is unchanged for self-hosters who haven't updated yet. Also adds a `MutationObserver` on the meta tag's `content` attribute so toggles propagate without waiting for the 2 s poll tick. Closes #70.
+
 ## [v1.6.1] — 2026-05-02
 
 ### Fixed

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -375,7 +375,31 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                         }
                         return null;
                     }
+                    // Prefer the WebUI's own theme-color meta tag when present.
+                    // hermes-webui v0.51.x+ exposes a <meta id="hermes-theme-color">
+                    // updated by boot.js whenever theme/skin changes; this is the
+                    // authoritative source of truth and is overlay-resistant
+                    // (modals/lightboxes can't poison it). When the tag is absent
+                    // (older server, raw page, error route) we fall back to pixel
+                    // sampling at three viewport interior points.
+                    function themeColorMetaBackground() {
+                        const meta = document.getElementById('hermes-theme-color');
+                        if (!meta) return null;
+                        const content = (meta.getAttribute('content') || '').trim();
+                        if (!content) return null;
+                        // Defensive: only trust values that match the forms our
+                        // Swift parseCSSColor() accepts (#RGB / #RRGGBB / rgb()
+                        // / rgba()). Anything else (e.g. an unresolved
+                        // `var(--bg)` from a future WebUI bug, an unknown CSS
+                        // colour name) falls through to pixel-sampling rather
+                        // than poisoning lastReportedHex with garbage and
+                        // suppressing every subsequent valid sample.
+                        if (!/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$|^rgba?\\(/.test(content)) return null;
+                        return content;
+                    }
                     function effectiveBackground() {
+                        const meta = themeColorMetaBackground();
+                        if (meta) return meta;
                         const w = window.innerWidth || 1280;
                         const h = window.innerHeight || 800;
                         // Sample a few interior points so a single oddly-coloured
@@ -447,6 +471,17 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                             observer.observe(document.body, {
                                 attributes: true,
                                 attributeFilter: ['class', 'data-theme', 'style', 'data-mode']
+                            });
+                        }
+                        // Watch the theme-color meta tag's content attribute too
+                        // — this is the new authoritative signal in v0.51.x+.
+                        // boot.js updates it on every theme/skin change, so we
+                        // catch toggles without waiting for the 2s poll tick.
+                        const themeMeta = document.getElementById('hermes-theme-color');
+                        if (themeMeta) {
+                            observer.observe(themeMeta, {
+                                attributes: true,
+                                attributeFilter: ['content']
                             });
                         }
                         // Belt-and-suspenders: poll every 2s. Web apps that toggle


### PR DESCRIPTION
# fix: theme bridge reads `<meta name="theme-color">` first, falls back to pixel sample (#70)

## What this PR is

A surgical fix for the bug Cygnus filed in #70 — multi-tab sessions in v1.6.1 have a tab-bar / title-bar strip that flashes bright white for an unpredictable period, and **stays stuck after closing the offending tab**. She explicitly flagged this as an accessibility / photosensitivity concern: *"I may not be too useful testing this particular feature one because it genuinely gives me a headache"*.

JS-only changes inside the existing `themeBridgeScript` `WKUserScript` template literal. **No Swift code added or removed.**

## Root cause

v1.6.1's bridge samples the WebContent's background by walking `document.elementsFromPoint(x, y)` at three fixed viewport coordinates and reporting the first opaque background it finds. The whole architecture is fragile against legitimate page overlays:

- Any modal, lightbox, settings panel, file-tree overlay, or image preview that covers any of the three sample points and stays visible past the 2.5s stability gate makes the bridge fire the **overlay's** colour.
- `AppDelegate.updateAppearance` propagates that colour to **every** browser window. With multi-tab, one tab's overlay-derived colour poisons the chrome of every other tab.
- Surviving windows' bridges then match-suppress further dark samples (`lastReportedHex` is now white), so the chrome stays white indefinitely — exactly Cygnus's *"stays that way after I close one of the tabs, I gotta wait for my long thing to finish running before I can refresh"*.

## The fix

A companion PR landed on the WebUI side (https://github.com/nesquena/hermes-webui/pull/1748) exposing the active theme as `<meta name="theme-color" id="hermes-theme-color">` in the static `<head>`, updated by `boot.js` on every theme/skin change. The tag is page-controlled, not overlay-derived, and overlay-immune by construction.

This PR makes the bridge prefer that authoritative source:

```js
function themeColorMetaBackground() {
    const meta = document.getElementById('hermes-theme-color');
    if (!meta) return null;
    const content = (meta.getAttribute('content') || '').trim();
    if (!content) return null;
    // Defensive: only trust values that match the forms parseCSSColor()
    // accepts (#RGB / #RRGGBB / rgb() / rgba()).
    if (!/^#[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$|^rgba?\(/.test(content)) return null;
    return content;
}

function effectiveBackground() {
    const meta = themeColorMetaBackground();
    if (meta) return meta;
    // ... existing three-point pixel sampling fallback ...
}
```

Three deliberate properties:

1. **Meta tag preferred when present.** `effectiveBackground()` returns the meta value first; the pixel-sampling block is now the fallback.
2. **Backward compatible.** When the meta tag is absent (older WebUI servers, raw error pages, anyone running pre-v0.51.x on the server side), the function returns null and `effectiveBackground` falls through to the unchanged three-point sampling. Behaviour is byte-identical to v1.6.1 for those users.
3. **Regex-validated content.** Defensive shield against a future malformed meta value (e.g. an unresolved `var(--bg)` from a future WebUI bug, an unknown CSS colour name) poisoning `lastReportedHex` and reproducing #70 in a different shape. Anything that doesn't match the forms `parseCSSColor()` accepts falls through to pixel sampling instead of corrupting the suppression state.

The existing `MutationObserver` is also extended to watch the meta tag's `content` attribute so toggles propagate without waiting for the 2-second poll tick.

```js
const themeMeta = document.getElementById('hermes-theme-color');
if (themeMeta) {
    observer.observe(themeMeta, {
        attributes: true,
        attributeFilter: ['content']
    });
}
```

## What's NOT changed

- The 2.5-second stability gate is unchanged.
- Match-suppression on `lastReportedHex` is unchanged.
- The persisted UserDefaults theme cache (`loadCachedTheme()`, `persistCurrentTheme()`) is unchanged.
- `AppDelegate.updateAppearance` global-fanout is unchanged. With the meta tag as authoritative source, all windows pointing at the same WebUI now report the same value, so the fanout becomes correct-by-construction rather than buggy-and-papered-over. (Per-window scoping is a future enhancement worth considering only if multi-server-per-window becomes a real use case.)
- `Sources/HermesAgent/BrowserWindowController.swift` Swift code is unchanged. Diff is JS-only inside the template literal.

## Opus pre-commit review (1M context, full file inspection)

Caught one real bug before push:

- **Swift template-literal escaping.** My initial regex used `\(` which Swift's `"""` strings parse as a string interpolation marker. Fixed to `\\(` to match existing line 358's escaping. Without this catch, the file would have failed to compile on the Mac. Confirmed both regex sites in the file (line 358 and line 397) now use the same `rgba?\\(` form.

Hardening absorbed:

- The regex content-validation in `themeColorMetaBackground()` (the third deliberate property above). Opus's exact recommendation, accepted as written.

Verified clean by Opus:

- MutationObserver semantics — one observer instance can observe multiple unrelated nodes (documentElement, body, themeMeta) each with their own per-call `attributeFilter`. ✓
- Backward compatibility — bytes-identical pixel-sampling fallback when meta tag is absent. ✓
- No memory / retain concerns (JS-only changes). ✓

## Verification

The companion WebUI PR (#1748) was browser-verified end-to-end on port 8789 across light/dark themes and all skin variants (Default, Sienna, Sisyphus). Each skin's distinct `--bg` reaches the meta tag with exact hex match, no flicker.

```
light + Default → #FEFCF7
light + Sienna  → #FAF9F5
dark  + Sienna  → #1F1E1C
```

## Mac agent build verification request

@nesquena — would you mind running `swift build -c release && swift test && bash build.sh` on the Mac agent against this branch? The change is JS-only inside a Swift `"""` string, but I'd like to confirm nothing in the Swift compile pipeline trips on the regex character class or the template-literal contents before tagging v1.6.2. Branch: `fix/theme-bridge-meta-tag-and-per-window`.

Closes #70.

Refs nesquena/hermes-webui#1748.
