### PR TITLE
fix: native tab dividers + cross-tab web-UI theme sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.6.3] — 2026-05-06
+
+### Fixed
+- **Native AppKit tab dividers restored** — v1.6.0–v1.6.2 painted `NSWindow.backgroundColor` with the page's exact RGB so the title-bar zone matched the page edge seamlessly. With native tabs visible, that flat fill swamped the tab bar's translucent material — the dividers between tabs disappeared and the active tab no longer read as elevated. Fix: stop overriding `window.backgroundColor`. Let it fall back to AppKit's default for the current `NSAppearance` so the native tab bar paints with its system tonal materials. The SSH footer still tints with the exact page RGB (it has no native treatment to preserve). The WKWebView's `underPageBackgroundColor` and the documentStart background-paint script still backstop new-tab / reload paint with the cached theme, so the no-flicker behaviour from v1.6.1 (fix #52) is preserved.
+- **Cross-tab theme/skin propagation** — Changing the theme in one tab did not re-render sibling tabs — each WKWebView held its own rendered theme until manually reloaded, so users could see two tabs in different themes simultaneously. hermes-webui's `boot.js` does not listen for `storage` events (verified May 2026), so a shared `WKWebsiteDataStore` alone wasn't enough. Fix: when `AppDelegate.updateAppearance` fires (a tab's bridge reported a stable new colour passing the 2.5 s STABILITY_MS gate), broadcast a small JS snippet to every browser window's WKWebView calling `_applyTheme(localStorage.getItem('hermes-theme'))` and `_applySkin(...)` plus the picker-sync helpers. Those functions are top-level in `boot.js` (loaded as a regular `<script>`, not a module), making them globals on `window` and reachable from `evaluateJavaScript`. localStorage is shared across same-origin WKWebViews via the default data store, so each sibling tab reads the values the source tab just wrote via `_pickTheme`/`_pickSkin`. Idempotent on the source tab. `typeof === 'function'` guard handles tabs still mid-load. The cross-tab sync directly references `_applyTheme`/`_applySkin`/`_syncThemePicker`/`_syncSkinPicker` from hermes-webui's `boot.js` — if any of those are renamed or converted to ES module locals, the Mac shim breaks silently. Long-term shape: a stable `window.hermes.setTheme(theme, skin)` API on the web side.
+
 ## [v1.6.2] — 2026-05-06
 
 ### Fixed

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -51,15 +51,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// (matches the hardcoded #1a1a1a pre-paint background).
     var currentAppearance: NSAppearance? = NSAppearance(named: .darkAqua)
 
-    /// The window background colour matching the current web-UI theme. Used as
-    /// `NSWindow.backgroundColor` on browser windows so the tab-bar strip
-    /// blends with the page instead of showing through the hardcoded
-    /// pre-paint #1a1a1a. Defaults to that #1a1a1a so the very first window
-    /// looks right before the bridge fires.
+    /// The page-background colour the web UI most recently reported. Used to
+    /// tint the SSH footer (which has no native treatment) and as the WKWebView
+    /// underPageBackgroundColor / pre-paint backstop on new tabs and reloads.
+    /// We deliberately do NOT push this into `NSWindow.backgroundColor` —
+    /// doing so swamps the tab bar's native tonal contrast and produces a
+    /// flat, borderless tab strip. The window's appearance (.aqua/.darkAqua)
+    /// drives native chrome instead.
     var currentBackgroundColor: NSColor =
         NSColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1.0)
 
-    /// Apply a new appearance + window background colour to every Hermes window.
+    /// Apply a new appearance + page-background colour to every Hermes window.
     /// Called by the BrowserWindowController theme bridge when the web UI
     /// reports a new background.
     func updateAppearance(_ appearance: NSAppearance?, backgroundColor: NSColor? = nil) {
@@ -71,10 +73,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         for browser in browserWindows {
             if appearanceChanged { browser.window?.appearance = appearance }
             if let bg = backgroundColor {
-                browser.window?.backgroundColor = bg
-                // Push the colour through to the SSH footer so it matches the
-                // tab-bar strip (which paints with window.backgroundColor) one
-                // to one — same RGB for every chrome surface.
+                // SSH footer is the only chrome surface that takes the exact
+                // page RGB — it has no native treatment, so matching the page
+                // edge precisely reads as "page extends to the bottom of the
+                // window." The native title/tab bar zone is left to AppKit
+                // so its tonal materials and tab separators stay visible.
                 browser.applyChromeBackgroundColor(bg)
             }
         }
@@ -83,9 +86,49 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             errorWindow?.window?.appearance = appearance
             splashWindow?.window?.appearance = appearance
         }
+        // Cross-tab theme sync: when one tab's bridge fires, push the
+        // hermes-webui theme + skin from shared localStorage into every other
+        // browser window's WKWebView so all tabs in a group render the same
+        // theme. Without this, switching the theme in tab A leaves tabs B/C
+        // visually stuck on whatever theme they last loaded with — until the
+        // user manually reloads them. hermes-webui's boot.js doesn't listen
+        // for `storage` events (verified May 2026), so we drive the re-apply
+        // explicitly. `_applyTheme` and `_applySkin` are top-level functions
+        // in boot.js (loaded as a regular script, not a module), which makes
+        // them globals on `window` and reachable from `evaluateJavaScript`.
+        // Idempotent — re-applying the same theme is a no-op repaint.
+        if bgChanged { broadcastWebUIThemeSync() }
         // Persist so next launch + new tabs/windows can open with the last-seen
         // theme instead of flashing dark while the bridge re-checks.
         if bgChanged { persistCurrentTheme() }
+    }
+
+    /// Tell every browser window's WKWebView to re-apply theme + skin from
+    /// the (shared) localStorage. Called from updateAppearance when the
+    /// background colour changes, so all open tabs converge on whichever
+    /// tab's bridge fired most recently.
+    private func broadcastWebUIThemeSync() {
+        let script = """
+            (function() {
+                try {
+                    if (typeof _applyTheme === 'function') {
+                        _applyTheme(localStorage.getItem('hermes-theme') || 'dark');
+                    }
+                    if (typeof _applySkin === 'function') {
+                        _applySkin(localStorage.getItem('hermes-skin') || 'default');
+                    }
+                    if (typeof _syncThemePicker === 'function') {
+                        _syncThemePicker(localStorage.getItem('hermes-theme') || 'dark');
+                    }
+                    if (typeof _syncSkinPicker === 'function') {
+                        _syncSkinPicker(localStorage.getItem('hermes-skin') || 'default');
+                    }
+                } catch (e) { /* boot.js not yet loaded; next page load picks up the value */ }
+            })();
+            """
+        for browser in browserWindows {
+            browser.webViewForZoom?.evaluateJavaScript(script, completionHandler: nil)
+        }
     }
 
     // MARK: - Theme cache (UserDefaults)

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -161,17 +161,16 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             defer: false
         )
         window.title = title
-        // Fix #23 + #52: set native window background to a dark colour before
-        // content loads. Using a literal dark value (not windowBackgroundColor)
-        // ensures the gap between window-visible and first-paint is dark in
-        // *all* colour schemes — windowBackgroundColor is white in light mode.
-        // Multi-window theme tracking: if AppDelegate already knows the current
-        // theme background colour (a sibling browser window has reported), use
-        // that so this new window/tab opens with the right colour and the tab
-        // bar strip blends correctly. Falls back to the dark pre-paint colour
-        // for the very first window.
-        window.backgroundColor = (NSApp.delegate as? AppDelegate)?.currentBackgroundColor
-            ?? NSColor(red: 0.10, green: 0.10, blue: 0.10, alpha: 1.0)
+        // We deliberately leave `window.backgroundColor` at AppKit's default
+        // for this appearance. Earlier versions painted it with the exact
+        // page RGB so the title bar zone matched the page edge seamlessly,
+        // but with native tabs visible the tab bar's translucent material
+        // blended into that flat fill and lost its tonal contrast — the tab
+        // dividers became invisible. The new-tab pre-paint colour (the
+        // gap before WKWebView's first paint) is handled by
+        // `webView.underPageBackgroundColor` and the documentStart
+        // background-paint script, both keyed to the cached theme; setting
+        // window.backgroundColor here would only affect the tab strip.
         super.init(window: window)
 
         // Fix #57: extend web content under the native title bar.
@@ -608,11 +607,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // Only add status bar in SSH mode
         if connectionMode == "ssh" {
             // Plain NSView with an explicit colour — we want the SSH footer to
-            // match the page background EXACTLY, sharing the same RGB as the
-            // tab-bar strip (which shows window.backgroundColor through). An
-            // NSVisualEffectView would introduce vibrancy that tints the colour
-            // off, breaking the visual seam. The bar stays in sync via
-            // AppDelegate.updateAppearance → applyChromeBackgroundColor.
+            // match the page background EXACTLY, so the bottom edge reads as a
+            // continuation of the page. An NSVisualEffectView would introduce
+            // vibrancy that tints the colour off, breaking the visual seam.
+            // The bar stays in sync via AppDelegate.updateAppearance →
+            // applyChromeBackgroundColor.
             let bar = NSView(
                 frame: NSRect(x: 0, y: 0, width: bounds.width, height: statusBarHeight))
             bar.autoresizingMask = [.width]
@@ -1248,9 +1247,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     }
 
     /// Apply a new chrome background colour. Called by AppDelegate.updateAppearance
-    /// when the theme bridge reports a new web-UI background — keeps the SSH
-    /// status bar in lock-step with window.backgroundColor (which the tab-bar
-    /// strip shows through), so all three surfaces share the same exact RGB.
+    /// when the theme bridge reports a new web-UI background. Tints only the
+    /// SSH footer (which has no native AppKit treatment to preserve) with the
+    /// exact page RGB, so the bottom edge of the window reads as a continuation
+    /// of the page. The native title/tab bar is intentionally left alone so
+    /// AppKit can paint its own tonal materials and tab dividers.
     func applyChromeBackgroundColor(_ color: NSColor) {
         statusBar?.layer?.backgroundColor = color.cgColor
         // Re-resolve the separator colour in the new appearance so its tone

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -931,12 +931,15 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         // Theme bridge: web UI reports its effective background colour.
-        // Propagate BOTH the appearance (controls AppKit chrome variants) AND
-        // the actual NSColor (used as window.backgroundColor so the tab-bar
-        // strip blends with the page instead of showing the hardcoded #1a1a1a
-        // through). Without the second piece, the tab bar zone stays dark even
-        // with .aqua appearance because window.backgroundColor was hardcoded
-        // dark in init() to prevent the white-flash-on-launch (fix #52).
+        // Propagate BOTH the appearance (drives AppKit chrome variants — the
+        // .aqua/.darkAqua choice picks the title/tab bar's tonal materials)
+        // AND the actual NSColor (used to tint the SSH footer exactly so the
+        // bottom edge reads as a continuation of the page; also cached as
+        // AppDelegate.currentBackgroundColor for the WKWebView pre-paint
+        // backstop on new tabs and reloads). The native title/tab bar zone
+        // is intentionally NOT painted with this colour — doing so swamped
+        // the tab bar's translucent material and erased the dividers
+        // between tabs (regression fixed in v1.6.3).
         if message.name == "hermesTheme", let css = message.body as? String {
             guard let rgb = Self.parseCSSColor(css) else { return }
             let luminance = 0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b


### PR DESCRIPTION
## Summary

Two visual/UX fixes for v1.6.x's multi-tab chrome, both verified on the user's machine before commit.

- **Restore native AppKit tab dividers.** v1.6.0–v1.6.2 painted `window.backgroundColor` with the page's exact RGB so the title-bar zone matched the page edge seamlessly. With native tabs visible that flat fill swamped the tab bar's translucent material — the dividers between tabs disappeared and the active tab no longer read as elevated. Fix: stop overriding `window.backgroundColor`. Let it fall back to AppKit's default for the current `NSAppearance` so the native tab bar paints with its system tonal materials. The SSH footer still tints with the exact page RGB (it has no native treatment to preserve). The WKWebView's `underPageBackgroundColor` and the documentStart background-paint script still backstop new-tab / reload paint with the cached theme, so the no-flicker behaviour from v1.6.1 is preserved.

- **Cross-tab theme/skin propagation.** Changing the theme in one tab did not re-render sibling tabs — each WKWebView held its own rendered theme until manually reloaded, so the user could see two tabs in different themes simultaneously. hermes-webui's `boot.js` does not listen for `storage` events (verified May 2026), so a shared `WKWebsiteDataStore` alone wasn't enough. Fix: when `AppDelegate.updateAppearance` fires (a tab's bridge reported a stable new colour), broadcast a small JS snippet to every browser window's WKWebView that calls `boot.js`'s `_applyTheme(localStorage.getItem('hermes-theme'))` and `_applySkin(...)`. Those functions are top-level in `boot.js` (loaded as a regular `<script>`, not a module), making them globals on `window` and reachable from `evaluateJavaScript`. localStorage is shared across same-origin WKWebViews via the default data store, so each sibling tab reads the values the source tab just wrote via `_pickTheme`/`_pickSkin`. Idempotent on the source tab. `typeof === 'function'` guard handles tabs still mid-load.

## Cross-repo coupling note

The cross-tab sync directly references `_applyTheme` / `_applySkin` / `_syncThemePicker` / `_syncSkinPicker` from `hermes-webui`'s `boot.js`. If those are renamed, converted to ES module locals, or replaced with proper `storage`-event listeners, the Mac shim breaks silently (the `typeof` guard suppresses the error). The right long-term shape is a stable `window.hermes.setTheme(theme, skin)` API on the web side — file before adding more underscore-name dependencies.

## Test plan

- [x] `swift build -c release` clean (0 warnings)
- [x] `swift test` passes (22/22)
- [x] `bash build.sh` produces signed `.app`, installs to `/Applications`
- [x] User-confirmed visual: native tab dividers visible across light and dark themes
- [x] User-confirmed visual: changing theme in one tab propagates to all sibling tabs in the window group
- [ ] Reviewer: confirm Cmd+R no-flicker behaviour from v1.6.1 still intact
- [ ] Reviewer: confirm SSH-mode footer still matches page edge exactly under both themes
- [ ] Reviewer: confirm new-tab open does not flash dark when cached theme is light

🤖 Generated with [Claude Code](https://claude.com/claude-code)
