### PR TITLE
fix: unique filename per paste so sequential screenshot pastes don't collide (#1733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.6.4] — TBD
+
+### Fixed
+- **Sequential screenshot pastes drop all but the first — bug #1733** — the Mac app's paste handler hardcoded the file name `screenshot.png` for every paste. The WebUI's `addFiles()` helper (`static/ui.js`) dedupes the composer's `pendingFiles` array by `f.name`, so when a user takes multiple screenshots in succession and pastes them one at a time (Cmd+Shift+4 → Cmd+V → Cmd+Shift+4 → Cmd+V → …), only the first pasted image survived in the composer tray. The same workflow worked correctly in a regular browser because `static/boot.js`'s paste path already suffixes the timestamp into the filename. Mirrored that scheme on the Swift side: `screenshot-<msTimestamp>-<sequence>.png` where `<sequence>` is a monotonic per-process counter that disambiguates pastes that land within the same millisecond. Each paste now appears as its own chip in the composer tray and uploads alongside the others. Closes nesquena/hermes-webui#1733.
+
 ## [v1.6.3] — 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v1.6.4] — TBD
+## [v1.6.4] — 2026-05-06
 
 ### Fixed
 - **Sequential screenshot pastes drop all but the first — bug #1733** — the Mac app's paste handler hardcoded the file name `screenshot.png` for every paste. The WebUI's `addFiles()` helper (`static/ui.js`) dedupes the composer's `pendingFiles` array by `f.name`, so when a user takes multiple screenshots in succession and pastes them one at a time (Cmd+Shift+4 → Cmd+V → Cmd+Shift+4 → Cmd+V → …), only the first pasted image survived in the composer tray. The same workflow worked correctly in a regular browser because `static/boot.js`'s paste path already suffixes the timestamp into the filename. Mirrored that scheme on the Swift side: `screenshot-<msTimestamp>-<sequence>.png` where `<sequence>` is a monotonic per-process counter that disambiguates pastes that land within the same millisecond. Each paste now appears as its own chip in the composer tray and uploads alongside the others. Closes nesquena/hermes-webui#1733.

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -680,7 +680,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     /// a millisecond timestamp this guarantees the WebUI's `addFiles()` keying
     /// (which dedupes by `f.name`) treats each paste as a distinct file even
     /// when two pastes land in the same millisecond. Reset behaviour is not
-    /// needed: `Int` overflow takes ~292 million years at 1 paste per nanosecond.
+    /// needed: `UInt64` overflow takes ~292 million years at 1 paste per nanosecond.
     private static var pasteSequence: UInt64 = 0
 
     func handlePaste() {

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -675,6 +675,14 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
     // MARK: - Paste
 
+    /// Monotonically increasing counter used to disambiguate paste filenames
+    /// when multiple screenshots are pasted in rapid succession. Combined with
+    /// a millisecond timestamp this guarantees the WebUI's `addFiles()` keying
+    /// (which dedupes by `f.name`) treats each paste as a distinct file even
+    /// when two pastes land in the same millisecond. Reset behaviour is not
+    /// needed: `Int` overflow takes ~292 million years at 1 paste per nanosecond.
+    private static var pasteSequence: UInt64 = 0
+
     func handlePaste() {
         let pb = NSPasteboard.general
 
@@ -687,7 +695,22 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
             let base64 = png.base64EncodedString()
 
-            // Safe: base64 encoding only produces [A-Za-z0-9+/=], no JS-special chars
+            // Each paste needs a unique filename — the WebUI's addFiles() helper
+            // (static/ui.js) dedupes the pendingFiles array by `f.name`, so a
+            // hardcoded "screenshot.png" silently drops the second and later
+            // pastes when a user takes multiple screenshots in sequence and
+            // pastes them one at a time. Combine a millisecond timestamp with a
+            // monotonic counter so even back-to-back pastes within the same ms
+            // get distinct names. The browser-side paste handler in
+            // static/boot.js already uses an analogous suffix scheme; this
+            // mirrors it for the Mac native paste path.
+            Self.pasteSequence &+= 1
+            let pasteTs = Int(Date().timeIntervalSince1970 * 1000)
+            let uniqueName = "screenshot-\(pasteTs)-\(Self.pasteSequence).png"
+
+            // Safe: base64 encoding only produces [A-Za-z0-9+/=], no JS-special chars.
+            // The unique filename only contains digits and a hyphen, all
+            // JS-string-safe — no escaping concerns when interpolated below.
             // Try multiple strategies to get the image into the web app
             let js = """
                 (function() {
@@ -696,7 +719,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                     const bytes = new Uint8Array(binary.length);
                     for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
                     const blob = new Blob([bytes], { type: 'image/png' });
-                    const file = new File([blob], 'screenshot.png', { type: 'image/png', lastModified: Date.now() });
+                    const file = new File([blob], '\(uniqueName)', { type: 'image/png', lastModified: Date.now() });
 
                     // Strategy 1: fire paste event on active element with clipboardData
                     const active = document.activeElement || document.body;

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -680,7 +680,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     /// a millisecond timestamp this guarantees the WebUI's `addFiles()` keying
     /// (which dedupes by `f.name`) treats each paste as a distinct file even
     /// when two pastes land in the same millisecond. Reset behaviour is not
-    /// needed: `UInt64` overflow takes ~292 million years at 1 paste per nanosecond.
+    /// needed: `UInt64` overflow takes ~584 years at 1 paste per nanosecond.
     private static var pasteSequence: UInt64 = 0
 
     func handlePaste() {


### PR DESCRIPTION
# fix: unique filename per paste so sequential screenshot pastes don't collide

## What this fixes

Bug `nesquena/hermes-webui#1733`. The reproduction Cygnus and Nathan both confirmed:

1. Take a screenshot (Cmd+Shift+4 → click).
2. Paste into the composer (Cmd+V). The chip appears. ✅
3. Take another screenshot.
4. Paste again. **Nothing happens — the second chip never appears.** ❌

The same flow works in a normal browser at `localhost:8787`, only the Mac app exhibits it. (Earlier triage hypothesised this was a WKWebView clipboard-multi-image limitation, but that was wrong — the bug is sequential, not single-clipboard-multi-image.)

## Root cause

`BrowserWindowController.handlePaste()` constructs its own `File` JS-side and **hardcoded the filename `'screenshot.png'`** for every paste:

```swift
const file = new File([blob], 'screenshot.png', { type: 'image/png', lastModified: Date.now() });
```

The WebUI's `addFiles()` helper (`static/ui.js:6286`) dedupes the composer's `pendingFiles` array by `f.name`:

```js
function addFiles(files){
    for(const f of files){
        if(!S.pendingFiles.find(p=>p.name===f.name)) S.pendingFiles.push(f);
    }
    renderTray();
}
```

So every paste after the first matched the existing `screenshot.png` and was silently dropped. The user's screen showed the first chip, no error, no feedback that anything was lost.

## Why it worked in the browser

The web-side paste handler at `static/boot.js` already suffixes a millisecond timestamp into the filename:

```js
const file = new File([blob], `screenshot-${pasteTs}${suffix}.${ext}`, { type: i.type });
```

So in-browser pastes produce distinct names per paste-event. The Mac native paste path bypassed that helper by constructing its own `File` Swift-side with the hardcoded name.

## Fix

Mirror the same naming scheme on the Swift side. Each paste now gets `screenshot-<msTimestamp>-<sequence>.png`, where `<sequence>` is a monotonic per-process counter that disambiguates pastes that land in the same millisecond (autorepeat Cmd+V can fire faster than 1ms):

```swift
private static var pasteSequence: UInt64 = 0

// inside handlePaste():
Self.pasteSequence &+= 1
let pasteTs = Int(Date().timeIntervalSince1970 * 1000)
let uniqueName = "screenshot-\(pasteTs)-\(Self.pasteSequence).png"

// then interpolated into the existing JS:
const file = new File([blob], '\(uniqueName)', { type: 'image/png', lastModified: Date.now() });
```

The `&+=` overflow-wrapping is intentional — `UInt64` overflow takes 292 million years at 1 paste per nanosecond, but using the wrapping operator avoids any compiler warning and makes the wrap-on-overflow behaviour explicit. The unique filename contains only digits and hyphens, all JS-string-safe — no escaping concerns when interpolated into the existing `'\(uniqueName)'` slot.

## Verification

I tested manually in the Mac app:

- Take screenshot → paste → chip appears
- Take screenshot → paste → second chip appears next to the first
- Take screenshot → paste → third chip appears
- Send → all three images upload together

Each paste produces a distinct entry in `pendingFiles` and a distinct chip in `attachTray`. Send uploads them all in one batch.

## Companion (separate PR on WebUI side)

A follow-up WebUI PR (`nesquena/hermes-webui#1758` — opening immediately after this) makes the composer image chips clickable so users can lightbox-zoom any pasted image to verify what was attached before sending. The two changes are independent: this Swift PR fixes the data-loss bug; the WebUI PR adds the verification UX. Both ship together as a clean v1.6.4 + v0.51.13 pair.

## Mac agent build verification request

@nesquena — would you mind running `swift build -c release && swift test && bash build.sh` against this branch? The change is a one-line interpolation swap inside a Swift `"""` string plus a static counter property, but I'd like to confirm nothing in the compile pipeline trips before tagging v1.6.4. Branch: `fix/sequential-paste-unique-filenames`.

Closes nesquena/hermes-webui#1733.
