### PR TITLE
fix: allow artifact downloads in desktop client

### DIFF
--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -1162,6 +1162,10 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         download.delegate = self
     }
 
+    func webView(_ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload) {
+        download.delegate = self
+    }
+
     // MARK: - File upload
 
     func webView(
@@ -1193,6 +1197,15 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
             return
         }
 
+        // An HTML download attribute becomes a navigation action before a
+        // response is available. Handle it before the generic API guard below;
+        // Hermes WebUI artifact links use /api/media and would otherwise be
+        // cancelled before WKWebView can create a WKDownload.
+        if navigationAction.shouldPerformDownload {
+            decisionHandler(.download)
+            return
+        }
+
         // Defense-in-depth (#76): API endpoints should never become full-page
         // navigations. The WebUI's JS treats /api/* as fetch targets only, and
         // every API error response uses the JSON shape `{"error": "..."}` —
@@ -1204,8 +1217,11 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         // chance to retry the action. Companion WebUI-side fix at
         // nesquena/hermes-webui#1835 locks down the home route to never
         // return JSON; this Mac-side guard catches every other class of
-        // accidental API navigation regardless of WebUI state.
-        if url.path.hasPrefix("/api/") {
+        // accidental API navigation regardless of WebUI state. The explicit
+        // artifact endpoints remain eligible for response-time download
+        // detection via Content-Disposition.
+        let downloadAPIPaths = ["/api/media", "/api/file/raw", "/api/folder/download"]
+        if url.path.hasPrefix("/api/") && !downloadAPIPaths.contains(url.path) {
             decisionHandler(.cancel)
             return
         }

--- a/Tests/HermesAgentTests/ValidationTests.swift
+++ b/Tests/HermesAgentTests/ValidationTests.swift
@@ -206,15 +206,16 @@ final class AppearanceThresholdTests: XCTestCase {
 
 /// Tests for the /api/* navigation guard (issue #76).
 /// Mirrors the path-prefix check in BrowserWindowController.webView(_:decidePolicyFor:).
-/// API endpoints should never become full-page navigations — the WebUI's JS
-/// treats them as fetch targets only, and JSON error responses would render
-/// raw if a navigation slipped through.
+/// Ordinary API endpoints should never become full-page navigations, while
+/// Hermes artifact endpoints must remain reachable so WKWebView can turn an
+/// attachment response into a native download.
 final class APINavigationGuardTests: XCTestCase {
-
     // Mirrors BrowserWindowController.webView(_:decidePolicyFor:) check
-    func shouldCancelAsAPINav(_ urlString: String) -> Bool {
+    func shouldCancelAsAPINav(_ urlString: String, shouldPerformDownload: Bool = false) -> Bool {
         guard let url = URL(string: urlString) else { return false }
-        return url.path.hasPrefix("/api/")
+        if shouldPerformDownload { return false }
+        let downloadAPIPaths = ["/api/media", "/api/file/raw", "/api/folder/download"]
+        return url.path.hasPrefix("/api/") && !downloadAPIPaths.contains(url.path)
     }
 
     func testApiPathsAreCancelled() {
@@ -222,6 +223,16 @@ final class APINavigationGuardTests: XCTestCase {
         XCTAssertTrue(shouldCancelAsAPINav("http://localhost:8787/api/updates/apply"))
         XCTAssertTrue(shouldCancelAsAPINav("http://localhost:8787/api/chat/stream"))
         XCTAssertTrue(shouldCancelAsAPINav("https://my-server.example.com/api/anything"))
+    }
+
+    func testArtifactDownloadsAreNotCancelled() {
+        XCTAssertFalse(shouldCancelAsAPINav("http://localhost:8787/api/media"))
+        XCTAssertFalse(shouldCancelAsAPINav("http://localhost:8787/api/file/raw"))
+        XCTAssertFalse(shouldCancelAsAPINav("http://localhost:8787/api/folder/download"))
+        XCTAssertFalse(shouldCancelAsAPINav(
+            "http://localhost:8787/api/anything",
+            shouldPerformDownload: true
+        ))
     }
 
     func testNonApiPathsAreAllowed() {


### PR DESCRIPTION
## Summary

Fixes desktop-client artifact downloads that currently do nothing when clicked.

- Route action-initiated HTML downloads through `WKDownload` before the generic `/api/` navigation guard.
- Attach the `WKDownloadDelegate` for action-initiated downloads as well as response-initiated downloads.
- Exempt the explicit artifact endpoints (`/api/media`, `/api/file/raw`, and `/api/folder/download`) from generic API-navigation cancellation so their `Content-Disposition: attachment` responses can reach the existing response-time download handler.
- Add regression coverage while preserving cancellation for ordinary API navigations.

## Reproduction

Hermes WebUI renders local artifact files as links such as:

```html
<a download href="api/media?path=...&download=1">📎 filename</a>
```

The Swift wrapper's navigation-action delegate canceled every `/api/*` request before WebKit could process the download action or receive the attachment response. The same authenticated `/api/media` endpoint returns `200` with `Content-Disposition: attachment` and downloads normally in Safari; the wrapper showed no visible result.

## Verification

- `git diff --check`
- Static policy-contract check confirming that `shouldPerformDownload` is evaluated before the API guard and that ordinary API navigation remains blocked.
- macOS runtime verification is intentionally left to CI/review: this patch requires an `NSSavePanel` for both a WebUI `📎` artifact link and a direct `/api/media?...&download=1` link. This Linux environment does not have Swift or Xcode installed.
