### PR TITLE
Strengthen the connection mechanism: fix tunnel bypass, support remote direct URLs, verify connections end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **SSH mode no longer bypasses the tunnel** — the browser loaded the raw Target URL instead of the tunnel entrance, so the `ssh -L` forward came up but carried no traffic (`netstat` showed a direct connection to the remote host). `AppDelegate.effectiveTargetURL()` now returns `http://127.0.0.1:<local port>` in SSH mode and the Target URL in Direct mode, applied to launch/reconnect, new windows/tabs, and View → Open in Browser.
+- **Direct mode works with non-localhost URLs (Tailscale/LAN hosts)** — a Target URL like `http://my-box.ts.net:8787` failed with "Cannot connect" even when the server was up: the WKWebView is ATS-exempt (`NSAllowsArbitraryLoadsInWebContent`) but the URLSession preflight, Test Connection, and health ping were not, so ATS rejected their plain-http requests to non-loopback hosts with -1022. All three now use `ReachabilityProbe`, which speaks HTTP over Network.framework (not subject to ATS).
+
+### Added
+- **Tri-state `/health` verification** — the probe issues a real `GET /health` (hand-rolled over NWConnection, TLS for https) rather than just connecting, so it can tell a healthy hermes (2xx + `"status": "ok"`) from a reverse proxy answering for a dead backend (reachable) from nothing listening (unreachable). Surfaced in Test Connection and the direct-mode title dot (● / ◐ / ○); the Dock "!" badge fires only on unreachable.
+- **End-to-end SSH Test Connection** — verifies a real non-interactive login (`ssh -o BatchMode=yes user@host exit`), distinguishing "✗ No SSH" from "✗ Auth failed" (keys refused → `ssh-copy-id` hint). On success it confirms hermes end-to-end: through the live tunnel when every forward-shaping setting matches, otherwise via a temporary `ssh -N -L` built from the fields and torn down after probing — so "✓ Hermes OK" means auth + forward + verified hermes. Reports "✗ Port busy" when the local port is taken (bind pre-check) and clears a stale result when any field or the mode changes.
+- **Preferences: Tunnel selector** — the mode segment is now "Tunnel: None | SSH" (persisted values unchanged); the SSH sections dim/disable instead of hiding, and in SSH mode the Target URL row becomes a read-only derived tunnel-entrance label.
+- **Plaintext-HTTP acknowledgment** — saving a Direct `http://` URL to a non-loopback host prompts a one-time per-host warning that credentials and session data cross the network unencrypted. Loopback is exempt.
+
+### Security
+- SSH username/host fields reject values that could smuggle ssh options (leading `-`, whitespace), enforced at Save, Test Connection, and in `testAuth`/`testForward`. The health probe builds its request from the percent-encoded URL path so encoded CR/LF can't reshape the request.
+
 ## [v1.7.0] — 2026-05-07
 
 ### Added

--- a/Sources/HermesAgent/AppDelegate.swift
+++ b/Sources/HermesAgent/AppDelegate.swift
@@ -256,10 +256,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// The URL browser windows actually load. In SSH mode this is always the
+    /// local tunnel entrance (http://127.0.0.1:<localPort>) — anything else
+    /// would connect straight to the remote host and bypass the ssh -L forward.
+    func effectiveTargetURL() -> String {
+        let defaults = UserDefaults.standard
+        let mode = defaults.string(forKey: "connectionMode") ?? "direct"
+        guard mode == "ssh" else {
+            return defaults.string(forKey: "targetURL") ?? defaultTargetURL
+        }
+        let localPort = Int(defaults.string(forKey: "localPort") ?? defaultLocalPort) ?? 8787
+        return "http://127.0.0.1:\(localPort)"
+    }
+
     func startTunnel() {
         let defaults = UserDefaults.standard
         let connectionMode = defaults.string(forKey: "connectionMode") ?? "direct"
-        let targetURL = defaults.string(forKey: "targetURL") ?? defaultTargetURL
+        let targetURL = effectiveTargetURL()
 
         let splashSubtitle = connectionMode == "ssh" ? "Establishing SSH tunnel…" : "Connecting…"
         splashWindow = SplashWindowController(title: appTitle, subtitle: splashSubtitle)
@@ -336,7 +349,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         } else {
-            preflightHTTP(urlString: targetURL) { reachable in
+            preflightReachability(urlString: targetURL) { reachable in
                 DispatchQueue.main.async {
                     self.splashWindow.close()
                     if reachable {
@@ -526,7 +539,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func openNewBrowserSession(asTab: Bool) {
         let defaults = UserDefaults.standard
         let mode = defaults.string(forKey: "connectionMode") ?? "direct"
-        let targetURL = defaults.string(forKey: "targetURL") ?? defaultTargetURL
+        let targetURL = effectiveTargetURL()
         if mode == "ssh" && tunnelManager?.status != .connected { return }
         if mode == "direct" && browserWindows.isEmpty {
             // No live first window in direct mode either — let startTunnel handle it.
@@ -573,22 +586,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         setOfflineBadge(true)
     }
 
-    /// Verify the target URL answers HTTP before opening the main browser.
-    /// Any HTTPURLResponse (including 4xx/5xx) counts as reachable — we only
-    /// fail on transport errors (connection refused, reset, timeout).
-    private func preflightHTTP(
+    /// Verify something is listening at the target URL before opening the
+    /// main browser. Must use the ATS-free probe, not URLSession — ATS blocks
+    /// plain-http URLSession requests to non-loopback hosts that the WKWebView
+    /// (exempt via NSAllowsArbitraryLoadsInWebContent) can load fine.
+    /// Merely-reachable (port open, /health unverified) still opens the
+    /// browser: whatever the server actually serves — even a proxy error —
+    /// is better diagnostics than our generic error window.
+    private func preflightReachability(
         urlString: String, timeout: TimeInterval = 4.0,
         completion: @escaping (Bool) -> Void
     ) {
-        guard let url = URL(string: urlString) else {
-            completion(false)
-            return
+        ReachabilityProbe.probeHealth(urlString: urlString, timeout: timeout) { result in
+            completion(result != .unreachable)
         }
-        var request = URLRequest(url: url, timeoutInterval: timeout)
-        request.httpMethod = "GET"
-        URLSession.shared.dataTask(with: request) { _, response, _ in
-            completion(response is HTTPURLResponse)
-        }.resume()
     }
 
     // MARK: - Dock badge (fix #39)
@@ -831,8 +842,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Open in system browser (bonus feature)
 
     @objc func openInBrowser() {
-        let urlString = UserDefaults.standard.string(forKey: "targetURL") ?? "http://localhost:8787"
-        if let url = URL(string: urlString) {
+        // In SSH mode the reachable address is the tunnel entrance, not the
+        // remote host — same rule as the in-app browser.
+        if let url = URL(string: effectiveTargetURL()) {
             NSWorkspace.shared.open(url)
         }
     }

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -131,9 +131,10 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     var isIntentionalClose = false
 
     // Health check timer for direct mode — polls /health every 30s and
-    // reflects status in the window title (fix #29).
+    // reflects status in the window title (fix #29). Tri-state: "port open
+    // but /health failing" (reverse proxy up, hermes down) is its own state.
     private var healthTimer: Timer?
-    private var isHealthy: Bool = true
+    private var healthState: HealthProbeResult = .healthy
 
     /// KVO observation for window.tabbedWindows. When AppKit adds or removes a
     /// tab from the group, the tab bar appears/disappears, which shifts the
@@ -704,7 +705,7 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
 
         // Start health polling for direct mode (fix #29)
         if connectionMode == "direct" {
-            updateWindowTitle(healthy: true)
+            updateWindowTitle()
             startHealthCheck()
         }
 
@@ -829,9 +830,8 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
     // MARK: Health check (direct mode, fix #29)
 
     private func startHealthCheck() {
-        let healthURL = urlString.hasSuffix("/") ? "\(urlString)health" : "\(urlString)/health"
         healthTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
-            self?.pingHealth(urlString: healthURL)
+            self?.pingHealth()
         }
     }
 
@@ -840,24 +840,25 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         healthTimer = nil
     }
 
-    private func pingHealth(urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        var request = URLRequest(url: url, timeoutInterval: 5)
-        request.httpMethod = "GET"
-        URLSession.shared.dataTask(with: request) { [weak self] _, response, _ in
-            let healthy = response is HTTPURLResponse
+    private func pingHealth() {
+        // Must be the ATS-free probe, not URLSession — ATS rejects plain-http
+        // to non-loopback hosts, which would pin remote direct-mode URLs
+        // (Tailscale/LAN) at "offline" regardless of actual server state.
+        ReachabilityProbe.probeHealth(urlString: urlString, timeout: 5) { [weak self] state in
             DispatchQueue.main.async {
-                guard let self = self, healthy != self.isHealthy else { return }
-                self.isHealthy = healthy
-                self.updateWindowTitle(healthy: healthy)
+                guard let self = self, state != self.healthState else { return }
+                self.healthState = state
+                self.updateWindowTitle()
             }
-        }.resume()
+        }
     }
 
-    private func updateWindowTitle(healthy: Bool) {
+    private func updateWindowTitle() {
         // Update Dock badge first so it stays accurate even when the tab title
-        // is fed from document.title (which doesn't carry health info).
-        (NSApp.delegate as? AppDelegate)?.setOfflineBadge(!healthy)
+        // is fed from document.title (which doesn't carry health info). The
+        // badge means "can't reach the server at all"; degraded /health only
+        // shows in the title dot.
+        (NSApp.delegate as? AppDelegate)?.setOfflineBadge(healthState == .unreachable)
         refreshTabTitle()
     }
 
@@ -886,7 +887,13 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
                 ? String(pageTitle.prefix(38)) + "…"
                 : pageTitle
         } else if connectionMode == "direct" {
-            let dot = isHealthy ? "●" : "○"
+            // ● /health verified · ◐ port answers, /health doesn't · ○ dead
+            let dot: String
+            switch healthState {
+            case .healthy: dot = "●"
+            case .reachable: dot = "◐"
+            case .unreachable: dot = "○"
+            }
             let host: String
             if let url = URL(string: urlString), let h = url.host {
                 let port = url.port.map { ":\($0)" } ?? ""

--- a/Sources/HermesAgent/PreferencesWindowController.swift
+++ b/Sources/HermesAgent/PreferencesWindowController.swift
@@ -12,6 +12,9 @@ class PreferencesWindowController: NSWindowController {
     private var localPortField: NSTextField!
     private var remotePortField: NSTextField!
     private var targetURLField: NSTextField!
+    /// Replaces the Target URL field in SSH mode, where the URL is derived
+    /// from the local port (the tunnel entrance) rather than typed.
+    private var tunnelURLLabel: NSTextField!
     private var testResultLabel: NSTextField!
     private var launchAtLoginCheckbox: NSButton!
     private var notificationsCheckbox: NSButton!
@@ -89,16 +92,18 @@ class PreferencesWindowController: NSWindowController {
             return line
         }
 
-        // Connection Mode
-        _ = sectionHeader("CONNECTION MODE")
-        let modeLabel = NSTextField(labelWithString: "Mode")
+        // Tunnel mechanism. "None" = the Target URL is reachable as-is;
+        // "SSH" = a forward is established first and the app loads the
+        // tunnel entrance. Persisted values are "direct"/"ssh".
+        _ = sectionHeader("TUNNEL")
+        let modeLabel = NSTextField(labelWithString: "Tunnel")
         modeLabel.font = NSFont.systemFont(ofSize: 13)
         modeLabel.frame = NSRect(x: 24, y: y, width: 130, height: 22)
         modeLabel.alignment = .right
         content.addSubview(modeLabel)
 
         connectionModeSegment = NSSegmentedControl(
-            labels: ["Direct (Local)", "SSH Tunnel"], trackingMode: .selectOne, target: self,
+            labels: ["None", "SSH"], trackingMode: .selectOne, target: self,
             action: #selector(modeChanged))
         connectionModeSegment.frame = NSRect(x: 164, y: y - 2, width: 300, height: 22)
         let mode = UserDefaults.standard.string(forKey: "connectionMode") ?? "direct"
@@ -109,15 +114,13 @@ class PreferencesWindowController: NSWindowController {
         let divider1 = divider()
         sshViews.append(divider1)
 
-        // SSH Connection section (shown only in SSH mode)
+        // SSH section — always visible; dimmed/disabled when tunnel is None
+        // so the fixed-frame layout keeps its shape.
         let sshHeader = sectionHeader("SSH CONNECTION")
         sshViews.append(sshHeader)
-        sshHeader.isHidden = mode == "direct"
 
         usernameField = row("Username", placeholder: "hermes", defaultsKey: "sshUser", isSSH: true)
-        usernameField.isHidden = mode == "direct"
         hostField = row("Host", placeholder: "your-server.com", defaultsKey: "sshHost", isSSH: true)
-        hostField.isHidden = mode == "direct"
 
         let divider2 = divider()
         sshViews.append(divider2)
@@ -125,14 +128,11 @@ class PreferencesWindowController: NSWindowController {
         // Port forwarding section
         let portHeader = sectionHeader("PORT FORWARDING")
         sshViews.append(portHeader)
-        portHeader.isHidden = mode == "direct"
 
         localPortField = row(
             "Local port", placeholder: "8787", defaultsKey: "localPort", width: 80, isSSH: true)
-        localPortField.isHidden = mode == "direct"
         remotePortField = row(
             "Remote port", placeholder: "8787", defaultsKey: "remotePort", width: 80, isSSH: true)
-        remotePortField.isHidden = mode == "direct"
 
         _ = divider()
 
@@ -140,6 +140,18 @@ class PreferencesWindowController: NSWindowController {
         _ = sectionHeader("APP")
         targetURLField = row(
             "Target URL", placeholder: "http://localhost:8787", defaultsKey: "targetURL")
+        // In SSH mode the URL is derived from the local port; a read-only
+        // label can't silently disagree with the tunnel the way an editable
+        // field could.
+        tunnelURLLabel = NSTextField(labelWithString: "")
+        tunnelURLLabel.font = NSFont.systemFont(ofSize: 13)
+        tunnelURLLabel.textColor = .secondaryLabelColor
+        tunnelURLLabel.frame = targetURLField.frame
+        content.addSubview(tunnelURLLabel)
+        // Delegate on every connection field: edits clear a stale Test
+        // Connection result; the local port also drives the tunnel-URL label.
+        [usernameField, hostField, localPortField, remotePortField, targetURLField]
+            .forEach { $0?.delegate = self }
 
         // Fix #41: configurable global shortcut — replaced static label with recorder.
         let shortcutLabel = NSTextField(labelWithString: "Global shortcut:")
@@ -226,6 +238,9 @@ class PreferencesWindowController: NSWindowController {
         testResultLabel.textColor = .secondaryLabelColor
         testResultLabel.frame = NSRect(x: 164, y: 22, width: 90, height: 16)
         content.addSubview(testResultLabel)
+
+        // Apply the initial dim/enable + Target URL swap for the saved mode.
+        modeChanged()
     }
 
     // MARK: - Notifications toggle (fix #28)
@@ -271,22 +286,6 @@ class PreferencesWindowController: NSWindowController {
     @objc func save() {
         let connectionMode = connectionModeSegment.selectedSegment == 0 ? "direct" : "ssh"
 
-        guard !targetURLField.stringValue.isEmpty else {
-            let alert = NSAlert()
-            alert.messageText = "Missing fields"
-            alert.informativeText = "Please fill in the Target URL."
-            alert.runModal()
-            return
-        }
-
-        guard let targetURL = URL(string: targetURLField.stringValue),
-            let scheme = targetURL.scheme?.lowercased(),
-            ["http", "https"].contains(scheme)
-        else {
-            showValidationError("Target URL must be a valid http:// or https:// URL.")
-            return
-        }
-
         if connectionMode == "ssh" {
             guard !usernameField.stringValue.isEmpty,
                 !hostField.stringValue.isEmpty,
@@ -297,6 +296,14 @@ class PreferencesWindowController: NSWindowController {
                 alert.messageText = "Missing SSH fields"
                 alert.informativeText = "Please fill in all SSH settings."
                 alert.runModal()
+                return
+            }
+
+            guard TunnelManager.isValidSSHIdentifier(usernameField.stringValue),
+                TunnelManager.isValidSSHIdentifier(hostField.stringValue)
+            else {
+                showValidationError(
+                    "Username and host may not start with \"-\" or contain spaces.")
                 return
             }
 
@@ -319,8 +326,52 @@ class PreferencesWindowController: NSWindowController {
             defaults.set(hostField.stringValue, forKey: "sshHost")
             defaults.set(String(localPort), forKey: "localPort")
             defaults.set(String(remotePort), forKey: "remotePort")
-            defaults.set(targetURL.absoluteString, forKey: "targetURL")
+            // targetURL intentionally untouched: SSH mode always loads the
+            // tunnel entrance (AppDelegate.effectiveTargetURL), and the stored
+            // value is kept for when the user switches back to Direct.
         } else {
+            guard !targetURLField.stringValue.isEmpty else {
+                let alert = NSAlert()
+                alert.messageText = "Missing fields"
+                alert.informativeText = "Please fill in the Target URL."
+                alert.runModal()
+                return
+            }
+
+            guard let targetURL = URL(string: targetURLField.stringValue),
+                let scheme = targetURL.scheme?.lowercased(),
+                ["http", "https"].contains(scheme)
+            else {
+                showValidationError("Target URL must be a valid http:// or https:// URL.")
+                return
+            }
+
+            // Plain http to a non-loopback host sends credentials and session
+            // data unencrypted — require a one-time acknowledgment per host.
+            // Loopback is exempt: nothing leaves the machine, and the SSH
+            // tunnel entrance must never prompt.
+            if scheme == "http",
+                let host = targetURL.host?.lowercased(),
+                !Self.isLoopbackHost(host),
+                !acknowledgedPlaintextHosts.contains(host)
+            {
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = "Unencrypted connection"
+                alert.informativeText =
+                    "\"\(host)\" will be reached over plain HTTP — credentials, cookies, "
+                    + "and chat data will cross the network unencrypted.\n\n"
+                    + "Continue only if the path to the server is already protected "
+                    + "(Tailscale, VPN, trusted LAN). Otherwise use an https:// URL "
+                    + "or the SSH tunnel option.\n\n"
+                    + "You won't be asked again for this host."
+                alert.addButton(withTitle: "Use HTTP Anyway")
+                alert.addButton(withTitle: "Cancel")
+                guard alert.runModal() == .alertFirstButtonReturn else { return }
+                UserDefaults.standard.set(
+                    acknowledgedPlaintextHosts + [host], forKey: Self.plaintextHostsKey)
+            }
+
             let defaults = UserDefaults.standard
             defaults.set(connectionMode, forKey: "connectionMode")
             defaults.set(targetURL.absoluteString, forKey: "targetURL")
@@ -336,7 +387,41 @@ class PreferencesWindowController: NSWindowController {
 
     @objc func modeChanged() {
         let isSSHMode = connectionModeSegment.selectedSegment == 1
-        sshViews.forEach { $0.isHidden = !isSSHMode }
+        // Dim rather than hide so the fixed-frame layout keeps its shape;
+        // disable inputs so a dimmed field can't take focus or edits.
+        sshViews.forEach { view in
+            view.alphaValue = isSSHMode ? 1.0 : 0.35
+            if let field = view as? NSTextField, field.isBezeled {
+                field.isEnabled = isSSHMode
+            }
+        }
+        targetURLField.isHidden = isSSHMode
+        tunnelURLLabel.isHidden = !isSSHMode
+        refreshTunnelURLLabel()
+        // A test result only describes the settings that were tested.
+        clearTestResult()
+    }
+
+    private func clearTestResult() {
+        testResultLabel.stringValue = ""
+        testResultLabel.toolTip = nil
+    }
+
+    private func refreshTunnelURLLabel() {
+        let port = Int(localPortField.stringValue) ?? 8787
+        tunnelURLLabel.stringValue = "http://127.0.0.1:\(port)  (via SSH tunnel)"
+    }
+
+    // MARK: - Plaintext-HTTP acknowledgment
+
+    private static let plaintextHostsKey = "plaintextAcknowledgedHosts"
+
+    private var acknowledgedPlaintextHosts: [String] {
+        UserDefaults.standard.stringArray(forKey: Self.plaintextHostsKey) ?? []
+    }
+
+    static func isLoopbackHost(_ host: String) -> Bool {
+        return host == "localhost" || host == "127.0.0.1" || host == "::1"
     }
 
     private func showValidationError(_ message: String) {
@@ -347,11 +432,167 @@ class PreferencesWindowController: NSWindowController {
     }
 
     @objc func testConnection() {
+        let isSSHMode = connectionModeSegment.selectedSegment == 1
+
+        if isSSHMode {
+            // Hermes lives on the remote loopback — the only route to it is
+            // a tunnel. Stage 1 verifies auth with a real non-interactive
+            // login; stage 2 probes /health through the live tunnel when it
+            // matches these settings, otherwise through a temporary forward.
+            let host = hostField.stringValue
+            let user = usernameField.stringValue
+            guard TunnelManager.isValidSSHIdentifier(user),
+                TunnelManager.isValidSSHIdentifier(host)
+            else {
+                testResultLabel.stringValue = "Bad user/host"
+                testResultLabel.textColor = .systemRed
+                testResultLabel.toolTip =
+                    "Username and host must be non-empty and may not start "
+                    + "with \"-\" or contain spaces."
+                return
+            }
+            testResultLabel.stringValue = "Testing SSH…"
+            testResultLabel.textColor = .secondaryLabelColor
+            TunnelManager.testAuth(user: user, host: host) { [weak self] authResult in
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    switch authResult {
+                    case .unreachable:
+                        self.testResultLabel.stringValue = "✗ No SSH"
+                        self.testResultLabel.textColor = .systemRed
+                        self.testResultLabel.toolTip =
+                            "No usable SSH session with \(host) — connection refused, "
+                            + "timed out, or host key problem."
+                        return
+                    case .authFailed:
+                        self.testResultLabel.stringValue = "✗ Auth failed"
+                        self.testResultLabel.textColor = .systemRed
+                        self.testResultLabel.toolTip =
+                            "\(host) speaks SSH but refused key auth for \"\(user)\". "
+                            + "The tunnel needs passwordless keys — set them up with: "
+                            + "ssh-copy-id \(user)@\(host)"
+                        return
+                    case .authenticated:
+                        break
+                    }
+                    // The live tunnel can only vouch for the fields when every
+                    // forward-shaping setting matches what it was built from.
+                    let defaults = UserDefaults.standard
+                    let tunnelUp =
+                        (NSApp.delegate as? AppDelegate)?.tunnelManager?.status == .connected
+                    let fieldPort = self.localPortField.stringValue
+                    guard tunnelUp,
+                        defaults.string(forKey: "connectionMode") == "ssh",
+                        defaults.string(forKey: "sshHost") == host,
+                        defaults.string(forKey: "sshUser") == user,
+                        defaults.string(forKey: "localPort") == fieldPort,
+                        defaults.string(forKey: "remotePort")
+                            == self.remotePortField.stringValue,
+                        let port = Int(fieldPort)
+                    else {
+                        // No matching live tunnel: verify end-to-end through
+                        // a temporary forward built from the field settings.
+                        guard let localPort = Int(fieldPort),
+                            (1...65535).contains(localPort),
+                            let remotePort = Int(self.remotePortField.stringValue),
+                            (1...65535).contains(remotePort)
+                        else {
+                            self.testResultLabel.stringValue = "✗ Bad port"
+                            self.testResultLabel.textColor = .systemRed
+                            self.testResultLabel.toolTip =
+                                "Ports must be numbers between 1 and 65535."
+                            return
+                        }
+                        // If the app's own live tunnel holds the configured
+                        // local port, test through an ephemeral port instead:
+                        // Save & Reconnect frees the real one by stopping the
+                        // old tunnel. A foreign process on the port still
+                        // reports "✗ Port busy" via testForward's pre-check.
+                        var testLocalPort = localPort
+                        if tunnelUp,
+                            defaults.string(forKey: "connectionMode") == "ssh",
+                            defaults.string(forKey: "localPort") == fieldPort,
+                            let ephemeral = TunnelManager.freeEphemeralPort()
+                        {
+                            testLocalPort = ephemeral
+                        }
+                        self.testResultLabel.stringValue = "Testing tunnel…"
+                        self.testResultLabel.textColor = .secondaryLabelColor
+                        TunnelManager.testForward(
+                            user: user, host: host,
+                            localPort: testLocalPort, remotePort: remotePort
+                        ) { forwardResult in
+                            DispatchQueue.main.async {
+                                switch forwardResult {
+                                case .healthy:
+                                    self.testResultLabel.stringValue = "✓ Hermes OK"
+                                    self.testResultLabel.textColor = .systemGreen
+                                    self.testResultLabel.toolTip =
+                                        "SSH auth, port forward, and /health all verified "
+                                        + "end-to-end with these settings (via a temporary "
+                                        + "tunnel, now closed)."
+                                case .reachableNoHealth:
+                                    self.testResultLabel.stringValue = "◐ No /health"
+                                    self.testResultLabel.textColor = .systemOrange
+                                    self.testResultLabel.toolTip =
+                                        "SSH auth and the forward work, but /health didn't "
+                                        + "verify through the tunnel — is hermes running on "
+                                        + "the remote at 127.0.0.1:\(remotePort)?"
+                                case .localPortBusy:
+                                    self.testResultLabel.stringValue = "✗ Port busy"
+                                    self.testResultLabel.textColor = .systemRed
+                                    self.testResultLabel.toolTip =
+                                        "Local port \(localPort) is already in use on this "
+                                        + "Mac — choose a different local port."
+                                case .forwardFailed:
+                                    self.testResultLabel.stringValue = "✗ No forward"
+                                    self.testResultLabel.textColor = .systemRed
+                                    self.testResultLabel.toolTip =
+                                        "SSH authenticated, but the port forward could not "
+                                        + "be established."
+                                }
+                            }
+                        }
+                        return
+                    }
+                    self.testResultLabel.stringValue = "Testing tunnel…"
+                    self.testResultLabel.textColor = .secondaryLabelColor
+                    ReachabilityProbe.probeHealth(
+                        urlString: "http://127.0.0.1:\(port)", timeout: 5
+                    ) { result in
+                        DispatchQueue.main.async {
+                            switch result {
+                            case .healthy:
+                                self.testResultLabel.stringValue = "✓ Hermes OK"
+                                self.testResultLabel.textColor = .systemGreen
+                                self.testResultLabel.toolTip =
+                                    "/health verified end-to-end through the running tunnel."
+                            case .reachable:
+                                self.testResultLabel.stringValue = "◐ No /health"
+                                self.testResultLabel.textColor = .systemOrange
+                                self.testResultLabel.toolTip =
+                                    "The tunnel entrance answers but /health didn't verify — "
+                                    + "is hermes running on the remote side?"
+                            case .unreachable:
+                                self.testResultLabel.stringValue = "✗ Tunnel dead"
+                                self.testResultLabel.textColor = .systemOrange
+                                self.testResultLabel.toolTip =
+                                    "SSH auth works, but nothing responded through the tunnel "
+                                    + "entrance on 127.0.0.1:\(port). The forward may have died — "
+                                    + "Save & Reconnect to rebuild it."
+                            }
+                        }
+                    }
+                }
+            }
+            return
+        }
+
         let urlString = targetURLField.stringValue.isEmpty
             ? (UserDefaults.standard.string(forKey: "targetURL") ?? "http://localhost:8787")
             : targetURLField.stringValue
 
-        guard let url = URL(string: urlString) else {
+        guard URL(string: urlString)?.host != nil else {
             testResultLabel.stringValue = "Invalid URL"
             testResultLabel.textColor = .systemRed
             return
@@ -360,29 +601,44 @@ class PreferencesWindowController: NSWindowController {
         testResultLabel.stringValue = "Testing…"
         testResultLabel.textColor = .secondaryLabelColor
 
-        // Use GET (not HEAD) because many dev servers return 405/501 for HEAD
-        // even when they serve GET normally. Treat any HTTPURLResponse as
-        // reachable regardless of status code — if TCP+HTTP completed a
-        // round-trip, the server is up. Only a network-level failure (no
-        // response) counts as "Unreachable".
-        var request = URLRequest(url: url, timeoutInterval: 5)
-        request.httpMethod = "GET"
-
-        URLSession.shared.dataTask(with: request) { [weak self] _, response, _ in
+        // Tri-state: /health verified · port open but /health unverified
+        // (reverse proxy up, hermes down — or not a hermes at all) · dead.
+        ReachabilityProbe.probeHealth(urlString: urlString, timeout: 5) { [weak self] result in
             DispatchQueue.main.async {
                 guard let self = self else { return }
-                if response is HTTPURLResponse {
-                    self.testResultLabel.stringValue = "✓ Connected"
+                switch result {
+                case .healthy:
+                    self.testResultLabel.stringValue = "✓ Hermes OK"
                     self.testResultLabel.textColor = .systemGreen
-                } else {
+                    self.testResultLabel.toolTip = "/health answered — verified hermes server."
+                case .reachable:
+                    self.testResultLabel.stringValue = "◐ No /health"
+                    self.testResultLabel.textColor = .systemOrange
+                    self.testResultLabel.toolTip =
+                        "The port accepts connections but /health didn't verify — "
+                        + "possibly a reverse proxy in front of a stopped hermes, "
+                        + "or a different service on this port."
+                case .unreachable:
                     self.testResultLabel.stringValue = "✗ Unreachable"
                     self.testResultLabel.textColor = .systemRed
+                    self.testResultLabel.toolTip = "Nothing is accepting connections at this host/port."
                 }
             }
-        }.resume()
+        }
     }
 
     @objc func cancel() {
         close()
+    }
+}
+
+extension PreferencesWindowController: NSTextFieldDelegate {
+    func controlTextDidChange(_ obj: Notification) {
+        // Any edit invalidates a previous Test Connection result.
+        clearTestResult()
+        // Keep the derived tunnel-URL label in sync while the local port is typed.
+        if (obj.object as? NSTextField) === localPortField {
+            refreshTunnelURLLabel()
+        }
     }
 }

--- a/Sources/HermesAgent/ReachabilityProbe.swift
+++ b/Sources/HermesAgent/ReachabilityProbe.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Network
+
+/// ATS-free /health check over Network.framework.
+///
+/// URLSession enforces App Transport Security: with NSAllowsArbitraryLoads
+/// false (our Info.plist), plain-http requests to non-loopback hosts are
+/// rejected with -1022 — even ones the WKWebView (exempt via
+/// NSAllowsArbitraryLoadsInWebContent) can load fine. Network.framework is
+/// not subject to ATS, so the HTTP GET is hand-rolled over NWConnection
+/// (TLS parameters for https). It speaks real HTTP to hermes-webui's /health
+/// route rather than just connecting: a bare TCP connect can't distinguish a
+/// healthy hermes from a reverse proxy answering for a dead backend.
+
+/// Result of a `/health` probe, ordered by how much it verifies.
+enum HealthProbeResult {
+    /// The endpoint answered `/health` with 2xx and a hermes-shaped body
+    /// (`"status": "ok"`). It really is a hermes server.
+    case healthy
+    /// Something is accepting connections at host:port, but `/health` did not
+    /// verify — e.g. a misbehaving reverse proxy in front of a dead backend,
+    /// a non-hermes service, or a non-2xx/garbled response.
+    case reachable
+    /// TCP connect failed or timed out.
+    case unreachable
+}
+
+enum ReachabilityProbe {
+
+    /// Probe an http(s) URL's `/health` endpoint. Completion fires exactly
+    /// once, on an arbitrary queue — callers hop to main themselves.
+    static func probeHealth(
+        urlString: String, timeout: TimeInterval = 4.0,
+        completion: @escaping (HealthProbeResult) -> Void
+    ) {
+        guard let url = URL(string: urlString),
+            let host = url.host, !host.isEmpty
+        else {
+            completion(.unreachable)
+            return
+        }
+        let scheme = url.scheme?.lowercased() ?? "http"
+        let port = url.port ?? (scheme == "https" ? 443 : 80)
+        guard (1...65535).contains(port),
+            let nwPort = NWEndpoint.Port(rawValue: UInt16(port))
+        else {
+            completion(.unreachable)
+            return
+        }
+
+        let connection = NWConnection(
+            host: NWEndpoint.Host(host), port: nwPort,
+            using: scheme == "https" ? .tls : .tcp)
+        let queue = DispatchQueue(label: "hermes.health.probe")
+        var finished = false
+        var connected = false
+        var received = Data()
+        func finish(_ result: HealthProbeResult) {
+            guard !finished else { return }
+            finished = true
+            connection.cancel()
+            completion(result)
+        }
+        func receiveLoop() {
+            connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+                data, _, isComplete, error in
+                if let data = data { received.append(data) }
+                if isComplete || error != nil || received.count > 256 * 1024 {
+                    finish(classifyHealthResponse(received))
+                } else {
+                    receiveLoop()
+                }
+            }
+        }
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                connected = true
+                // Percent-ENCODED path: URL.path percent-decodes, which would
+                // let encoded CR/LF in the configured URL reshape the
+                // hand-rolled request below.
+                let base = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+                    .percentEncodedPath ?? ""
+                let path = base.isEmpty || base == "/"
+                    ? "/health"
+                    : (base.hasSuffix("/") ? base + "health" : base + "/health")
+                let request = "GET \(path) HTTP/1.1\r\n"
+                    + "Host: \(host)\r\n"
+                    + "Accept: application/json\r\n"
+                    + "Connection: close\r\n\r\n"
+                connection.send(
+                    content: request.data(using: .utf8),
+                    completion: .contentProcessed { error in
+                        // TCP connected but the write died — port is open,
+                        // health unverifiable.
+                        if error != nil { finish(.reachable) }
+                    })
+                receiveLoop()
+            case .failed, .cancelled:
+                finish(connected ? .reachable : .unreachable)
+            default:
+                break
+            }
+        }
+        connection.start(queue: queue)
+        queue.asyncAfter(deadline: .now() + timeout) {
+            // Ran out of time: connected-with-partial-data still classifies
+            // (the status line usually arrives first); never-connected is dead.
+            if connected {
+                finish(classifyHealthResponse(received))
+            } else {
+                finish(.unreachable)
+            }
+        }
+    }
+
+    /// Classify a raw HTTP/1.x response to `GET /health`: 2xx plus a body
+    /// carrying `"status"` and `"ok"` is a verified hermes. Substring match
+    /// rather than JSON parse so a chunked transfer encoding (chunk-size
+    /// markers interleaved with the body) still classifies correctly.
+    static func classifyHealthResponse(_ raw: Data) -> HealthProbeResult {
+        guard !raw.isEmpty,
+            let text = String(data: raw, encoding: .utf8),
+            let statusLineEnd = text.range(of: "\r\n")
+        else { return .reachable }
+        let statusParts = text[..<statusLineEnd.lowerBound].split(separator: " ")
+        guard statusParts.count >= 2,
+            statusParts[0].hasPrefix("HTTP/"),
+            let code = Int(statusParts[1]),
+            (200...299).contains(code),
+            let headerEnd = text.range(of: "\r\n\r\n")
+        else { return .reachable }
+        let body = text[headerEnd.upperBound...]
+        return body.contains("\"status\"") && body.contains("\"ok\"")
+            ? .healthy : .reachable
+    }
+
+}

--- a/Sources/HermesAgent/TunnelManager.swift
+++ b/Sources/HermesAgent/TunnelManager.swift
@@ -6,6 +6,17 @@ enum TunnelStatus {
     case disconnected
 }
 
+/// Outcome of a non-interactive `ssh … exit` authentication test.
+enum SSHAuthResult {
+    /// Logged in and back out — TCP, SSH protocol, host key, and key auth
+    /// all work: everything the tunnel needs.
+    case authenticated
+    /// The host speaks SSH but refused our keys. Fix is ssh-copy-id.
+    case authFailed
+    /// Nothing usable at host:22 — refused, timed out, or DNS failure.
+    case unreachable
+}
+
 class TunnelManager {
     private var process: Process?
     private let user: String
@@ -24,6 +35,219 @@ class TunnelManager {
         self.localPort = localPort
         self.remoteHost = remoteHost
         self.remotePort = remotePort
+    }
+
+    /// True when a value is safe to pass to ssh as part of the user@host
+    /// target. ssh parses any argument beginning with "-" as an option, so a
+    /// username like "-oProxyCommand=…" would smuggle options into the
+    /// invocation (and ProxyCommand runs shell commands). Neither field can
+    /// legitimately contain whitespace.
+    static func isValidSSHIdentifier(_ value: String) -> Bool {
+        return !value.isEmpty
+            && !value.hasPrefix("-")
+            && value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil
+    }
+
+    /// Verify the tunnel could be established with these credentials by
+    /// running a real login: `ssh -o BatchMode=yes user@host exit`.
+    /// BatchMode forbids password prompts, so this can never hang on input;
+    /// StrictHostKeyChecking=accept-new matches start() so the test exercises
+    /// the same host-key path the tunnel will. Completion fires once, on a
+    /// background queue.
+    static func testAuth(
+        user: String, host: String, timeout: TimeInterval = 6.0,
+        completion: @escaping (SSHAuthResult) -> Void
+    ) {
+        guard isValidSSHIdentifier(user), isValidSSHIdentifier(host) else {
+            completion(.unreachable)
+            return
+        }
+        DispatchQueue.global().async {
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+            p.arguments = [
+                "-o", "BatchMode=yes",
+                "-o", "ConnectTimeout=\(Int(timeout))",
+                "-o", "StrictHostKeyChecking=accept-new",
+                "\(user)@\(host)",
+                "exit",
+            ]
+            let errPipe = Pipe()
+            p.standardError = errPipe
+            p.standardOutput = Pipe()
+            do {
+                try p.run()
+            } catch {
+                completion(.unreachable)
+                return
+            }
+            // Watchdog: ConnectTimeout only bounds the TCP phase; a stalled
+            // key exchange could hold the process open past it.
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeout + 2.0) {
+                if p.isRunning { p.terminate() }
+            }
+            p.waitUntilExit()
+            let stderr = String(
+                data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8) ?? ""
+            completion(Self.classifyAuthAttempt(
+                exitStatus: p.terminationStatus, stderr: stderr))
+        }
+    }
+
+    /// "Permission denied" is sshd's auth-rejection message — reaching it
+    /// means the whole transport worked and only our key was refused.
+    /// Any other nonzero outcome (refused, timed out, DNS, host key
+    /// mismatch, watchdog kill) means we never got a usable SSH session.
+    static func classifyAuthAttempt(exitStatus: Int32, stderr: String) -> SSHAuthResult {
+        if exitStatus == 0 { return .authenticated }
+        if stderr.contains("Permission denied") { return .authFailed }
+        return .unreachable
+    }
+
+    /// Outcome of an ephemeral end-to-end forward test (testForward).
+    enum ForwardTestResult {
+        /// Temporary tunnel came up and /health verified through it.
+        case healthy
+        /// Tunnel established, but /health didn't verify through it —
+        /// hermes down on the remote loopback, or not a hermes at all.
+        case reachableNoHealth
+        /// The local port is already taken on this Mac.
+        case localPortBusy
+        /// The forward never became usable.
+        case forwardFailed
+    }
+
+    /// Bring up a temporary `ssh -N -L` with these exact settings, probe
+    /// hermes' /health through it, then tear it down. Callers verify auth
+    /// first (testAuth) so a failure here means "the forward", not "the
+    /// login". Completion fires once, on a background queue.
+    static func testForward(
+        user: String, host: String, localPort: Int, remotePort: Int,
+        timeout: TimeInterval = 10.0,
+        completion: @escaping (ForwardTestResult) -> Void
+    ) {
+        guard isValidSSHIdentifier(user), isValidSSHIdentifier(host) else {
+            completion(.forwardFailed)
+            return
+        }
+        DispatchQueue.global().async {
+            guard localPortIsFree(localPort) else {
+                completion(.localPortBusy)
+                return
+            }
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+            p.arguments = [
+                "-N",
+                "-o", "BatchMode=yes",
+                "-o", "ConnectTimeout=\(Int(timeout))",
+                "-o", "StrictHostKeyChecking=accept-new",
+                "-o", "ExitOnForwardFailure=yes",
+                "-L", "\(localPort):127.0.0.1:\(remotePort)",
+                "\(user)@\(host)",
+            ]
+            let errPipe = Pipe()
+            p.standardError = errPipe
+            p.standardOutput = Pipe()
+            do {
+                try p.run()
+            } catch {
+                completion(.forwardFailed)
+                return
+            }
+            defer {
+                if p.isRunning { p.terminate() }
+            }
+            // Probe /health through the forward until something answers or
+            // time runs out. ssh accepts local connections as soon as the
+            // bind succeeds, so the probe outcome reflects the remote side.
+            let deadline = Date().addingTimeInterval(timeout)
+            var result = ForwardTestResult.forwardFailed
+            while Date() < deadline {
+                if !p.isRunning {
+                    // Died on its own (ExitOnForwardFailure, auth hiccup, …)
+                    let stderr = String(
+                        data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                        encoding: .utf8) ?? ""
+                    result = stderr.contains("Address already in use")
+                        ? .localPortBusy : .forwardFailed
+                    break
+                }
+                let semaphore = DispatchSemaphore(value: 0)
+                var outcome = HealthProbeResult.unreachable
+                ReachabilityProbe.probeHealth(
+                    urlString: "http://127.0.0.1:\(localPort)", timeout: 1.5
+                ) {
+                    outcome = $0
+                    semaphore.signal()
+                }
+                semaphore.wait()
+                if outcome == .healthy {
+                    result = .healthy
+                    break
+                }
+                if outcome == .reachable {
+                    result = .reachableNoHealth
+                    break
+                }
+                Thread.sleep(forTimeInterval: 0.4)
+            }
+            completion(result)
+        }
+    }
+
+    /// A loopback port the OS says is free right now (bind :0, read back the
+    /// assignment). Lets Test Connection route a test forward around a port
+    /// the app's own live tunnel is holding.
+    static func freeEphemeralPort() -> Int? {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+        defer { close(fd) }
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bound == 0 else { return nil }
+        var assigned = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let ok = withUnsafeMutablePointer(to: &assigned) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &len)
+            }
+        }
+        guard ok == 0 else { return nil }
+        let port = Int(UInt16(bigEndian: assigned.sin_port))
+        return port > 0 ? port : nil
+    }
+
+    /// True if 127.0.0.1:port can be bound right now. Checked before the
+    /// forward test launches ssh, so an unrelated local listener on the
+    /// port is reported as "busy" instead of being probed as if it were
+    /// the tunnel.
+    private static func localPortIsFree(_ port: Int) -> Bool {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return true }
+        defer { close(fd) }
+        var reuse: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        let bound = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        return bound == 0
     }
 
     func start(onReady: @escaping () -> Void) {

--- a/Tests/HermesAgentTests/ValidationTests.swift
+++ b/Tests/HermesAgentTests/ValidationTests.swift
@@ -151,6 +151,341 @@ final class SSHArgumentTests: XCTestCase {
 }
 
 
+/// Tests for the effective-URL rule (SSH tunnel bypass fix).
+/// Mirrors `AppDelegate.effectiveTargetURL()` — in SSH mode the browser must
+/// load the local tunnel entrance, never the configured Target URL. Loading
+/// the remote URL directly is exactly the bug this guards against: the
+/// ssh -L forward came up, was probed once, and then sat unused while the
+/// WKWebView connected straight to the remote host.
+final class EffectiveTargetURLTests: XCTestCase {
+
+    // Mirrors AppDelegate.effectiveTargetURL()
+    func effectiveURL(mode: String, targetURL: String, localPort: Int) -> String {
+        return mode == "ssh" ? "http://127.0.0.1:\(localPort)" : targetURL
+    }
+
+    func testSSHModeAlwaysLoadsTunnelEntrance() {
+        // Even with a remote Target URL configured, SSH mode must go through
+        // the tunnel — the remote URL is irrelevant to what the web view loads.
+        XCTAssertEqual(
+            effectiveURL(mode: "ssh", targetURL: "http://hermes.example.ts.net:8787", localPort: 8787),
+            "http://127.0.0.1:8787")
+        XCTAssertEqual(
+            effectiveURL(mode: "ssh", targetURL: "http://localhost:8787", localPort: 9000),
+            "http://127.0.0.1:9000")
+    }
+
+    func testDirectModePassesTargetURLThrough() {
+        XCTAssertEqual(
+            effectiveURL(mode: "direct", targetURL: "http://hermes.example.ts.net:8787", localPort: 8787),
+            "http://hermes.example.ts.net:8787")
+        XCTAssertEqual(
+            effectiveURL(mode: "direct", targetURL: "http://localhost:8787", localPort: 9000),
+            "http://localhost:8787")
+    }
+}
+
+/// Tests for the reachability probe's host/port derivation.
+/// Mirrors `ReachabilityProbe.probe(urlString:)` — the ATS-free TCP probe
+/// that replaced URLSession in preflight / Test Connection / health ping so
+/// direct mode works with non-localhost plain-http URLs.
+final class ProbeEndpointDerivationTests: XCTestCase {
+
+    // Mirrors the URL → (host, port) derivation in ReachabilityProbe
+    func derivedEndpoint(_ raw: String) -> (host: String, port: Int)? {
+        guard let url = URL(string: raw), let host = url.host, !host.isEmpty
+        else { return nil }
+        let port = url.port ?? (url.scheme?.lowercased() == "https" ? 443 : 80)
+        return (host, port)
+    }
+
+    func testExplicitPortPreserved() {
+        let ep = derivedEndpoint("http://hermes.example.ts.net:8787/")
+        XCTAssertEqual(ep?.host, "hermes.example.ts.net")
+        XCTAssertEqual(ep?.port, 8787)
+    }
+
+    func testHTTPDefaultsTo80() {
+        XCTAssertEqual(derivedEndpoint("http://example.com/")?.port, 80)
+    }
+
+    func testHTTPSDefaultsTo443() {
+        XCTAssertEqual(derivedEndpoint("https://example.com/")?.port, 443)
+    }
+
+    func testHostlessURLRejected() {
+        XCTAssertNil(derivedEndpoint(""))
+        XCTAssertNil(derivedEndpoint("http://"))
+    }
+
+    // Mirrors the request-path derivation in ReachabilityProbe.probeHealth:
+    // the percent-ENCODED path must be used, since URL.path decodes and
+    // would let encoded CR/LF reshape the hand-rolled HTTP request.
+    func testEncodedCRLFStaysEncodedInProbePath() {
+        let url = URL(string: "http://host:8787/%0D%0AX-Evil:1")!
+        let base = URLComponents(url: url, resolvingAgainstBaseURL: false)!.percentEncodedPath
+        XCTAssertFalse(base.contains("\r"))
+        XCTAssertFalse(base.contains("\n"))
+        XCTAssertTrue(base.contains("%0D%0A"))
+    }
+}
+
+/// Tests for the /health response classifier.
+/// Mirrors `ReachabilityProbe.classifyHealthResponse(_:)` — the tri-state
+/// that distinguishes a verified hermes server (2xx + `"status": "ok"` body)
+/// from "something answered but it's not a healthy hermes" (reverse proxy in
+/// front of a dead backend, other service on the port, non-2xx).
+final class HealthResponseClassificationTests: XCTestCase {
+
+    enum Result { case healthy, reachable }
+
+    // Mirrors ReachabilityProbe.classifyHealthResponse
+    func classify(_ raw: String) -> Result {
+        let text = raw
+        guard let statusLineEnd = text.range(of: "\r\n") else { return .reachable }
+        let statusParts = text[..<statusLineEnd.lowerBound].split(separator: " ")
+        guard statusParts.count >= 2,
+            statusParts[0].hasPrefix("HTTP/"),
+            let code = Int(statusParts[1]),
+            (200...299).contains(code),
+            let headerEnd = text.range(of: "\r\n\r\n")
+        else { return .reachable }
+        let body = text[headerEnd.upperBound...]
+        return body.contains("\"status\"") && body.contains("\"ok\"")
+            ? .healthy : .reachable
+    }
+
+    func testRealHermesHealthResponseIsHealthy() {
+        // Body shape captured from a live hermes server's /health.
+        let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n"
+            + #"{"status": "ok", "sessions": 5, "active_streams": 0, "uptime_seconds": 25012.3}"#
+        XCTAssertEqual(classify(response), .healthy)
+    }
+
+    func testChunkedHermesResponseStillHealthy() {
+        // Chunk-size markers interleave with the body; the substring check
+        // must survive them.
+        let response = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+            + "10\r\n{\"status\": \"ok\"\r\n1\r\n}\r\n0\r\n\r\n"
+        XCTAssertEqual(classify(response), .healthy)
+    }
+
+    func testNon2xxIsOnlyReachable() {
+        // Reverse proxy up, hermes down — the classic 502.
+        let response = "HTTP/1.1 502 Bad Gateway\r\n\r\n<html>nginx</html>"
+        XCTAssertEqual(classify(response), .reachable)
+    }
+
+    func test2xxWithoutHermesBodyIsOnlyReachable() {
+        // Some other service answering 200 on the port is not a hermes.
+        let response = "HTTP/1.1 200 OK\r\n\r\n<html>hello</html>"
+        XCTAssertEqual(classify(response), .reachable)
+    }
+
+    func testGarbageIsOnlyReachable() {
+        XCTAssertEqual(classify("SSH-2.0-OpenSSH_9.6\r\n"), .reachable)
+        XCTAssertEqual(classify("not http at all"), .reachable)
+    }
+}
+
+/// Tests for the ssh user/host field validation.
+/// Mirrors `TunnelManager.isValidSSHIdentifier(_:)` — ssh parses any argument
+/// beginning with "-" as an option, so an unvalidated username like
+/// "-oProxyCommand=…" smuggles options (and ProxyCommand runs shell commands)
+/// into the args array even though Process bypasses the shell.
+final class SSHIdentifierValidationTests: XCTestCase {
+
+    // Mirrors TunnelManager.isValidSSHIdentifier
+    func isValid(_ value: String) -> Bool {
+        return !value.isEmpty
+            && !value.hasPrefix("-")
+            && value.rangeOfCharacter(from: .whitespacesAndNewlines) == nil
+    }
+
+    func testNormalValuesAccepted() {
+        XCTAssertTrue(isValid("hermes"))
+        XCTAssertTrue(isValid("server.example.com"))
+        XCTAssertTrue(isValid("192.168.1.20"))
+        XCTAssertTrue(isValid("box.tail1234.ts.net"))
+    }
+
+    func testOptionSmugglingRejected() {
+        XCTAssertFalse(isValid("-oProxyCommand=touch /tmp/pwned"))
+        XCTAssertFalse(isValid("-v"))
+    }
+
+    func testWhitespaceRejected() {
+        XCTAssertFalse(isValid("user name"))
+        XCTAssertFalse(isValid("host\nname"))
+        XCTAssertFalse(isValid(" hermes"))
+    }
+
+    func testEmptyRejected() {
+        XCTAssertFalse(isValid(""))
+    }
+}
+
+/// Tests for the SSH auth-test classification.
+/// Mirrors `TunnelManager.classifyAuthAttempt(exitStatus:stderr:)` — the rule
+/// behind Test Connection's SSH verdicts. Exit 0 means a full login round
+/// trip (what the tunnel needs). "Permission denied" on stderr means the
+/// transport worked and only the key was refused — actionable (ssh-copy-id)
+/// and distinct from "nothing usable at host:22".
+final class SSHAuthClassificationTests: XCTestCase {
+
+    enum Result { case authenticated, authFailed, unreachable }
+
+    // Mirrors TunnelManager.classifyAuthAttempt
+    func classify(exitStatus: Int32, stderr: String) -> Result {
+        if exitStatus == 0 { return .authenticated }
+        if stderr.contains("Permission denied") { return .authFailed }
+        return .unreachable
+    }
+
+    func testCleanExitIsAuthenticated() {
+        XCTAssertEqual(classify(exitStatus: 0, stderr: ""), .authenticated)
+        // Warnings on stderr (e.g. accept-new adding a host key) don't matter
+        // if the login itself succeeded.
+        XCTAssertEqual(
+            classify(exitStatus: 0, stderr: "Warning: Permanently added 'host' to known hosts."),
+            .authenticated)
+    }
+
+    func testPermissionDeniedIsAuthFailure() {
+        XCTAssertEqual(
+            classify(exitStatus: 255, stderr: "user@host: Permission denied (publickey)."),
+            .authFailed)
+    }
+
+    func testTransportFailuresAreUnreachable() {
+        XCTAssertEqual(
+            classify(exitStatus: 255, stderr: "ssh: connect to host x port 22: Connection refused"),
+            .unreachable)
+        XCTAssertEqual(
+            classify(exitStatus: 255, stderr: "ssh: connect to host x port 22: Operation timed out"),
+            .unreachable)
+        XCTAssertEqual(
+            classify(exitStatus: 255, stderr: "ssh: Could not resolve hostname x"),
+            .unreachable)
+        // Watchdog kill (terminated, no informative stderr)
+        XCTAssertEqual(classify(exitStatus: 15, stderr: ""), .unreachable)
+    }
+
+    // Mirrors the died-early classification in TunnelManager.testForward:
+    // "Address already in use" on stderr means the local bind lost the race
+    // (ExitOnForwardFailure kills ssh); anything else is a generic forward
+    // failure.
+    func testForwardDeathClassification() {
+        func classify(_ stderr: String) -> String {
+            return stderr.contains("Address already in use") ? "localPortBusy" : "forwardFailed"
+        }
+        XCTAssertEqual(
+            classify("bind [127.0.0.1]:8787: Address already in use"), "localPortBusy")
+        XCTAssertEqual(classify("Could not request local forwarding."), "forwardFailed")
+        XCTAssertEqual(classify(""), "forwardFailed")
+    }
+
+    // Mirrors the argument array built in TunnelManager.testAuth — BatchMode
+    // is the security-relevant invariant: without it, ssh can stall forever
+    // on an interactive password prompt the user can't see.
+    func testAuthProbeArgsAreNonInteractive() {
+        let args = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=6",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "hermes@example.com",
+            "exit",
+        ]
+        XCTAssertTrue(args.contains("BatchMode=yes"))
+        XCTAssertTrue(args.contains("StrictHostKeyChecking=accept-new"))
+        XCTAssertEqual(args.last, "exit", "must run a no-op command and disconnect")
+    }
+}
+
+/// Tests for the "probe through the live tunnel" match rule.
+/// Mirrors the guard in PreferencesWindowController.testConnection: the
+/// already-running tunnel may only vouch for the fields when EVERY setting
+/// that shapes the forward matches. Regression: remotePort was originally
+/// missing from the match, so editing it to a dead port (8788) still probed
+/// the live tunnel's old forward (8787) and reported "✓ Hermes OK" for a
+/// configuration that was never tested.
+final class LiveTunnelMatchTests: XCTestCase {
+
+    struct Settings: Equatable {
+        var mode = "ssh"
+        var host = "hermes.example.ts.net"
+        var user = "hermes"
+        var localPort = "8787"
+        var remotePort = "8787"
+    }
+
+    // Mirrors the testConnection guard
+    func liveTunnelVouches(saved: Settings, fields: Settings, tunnelUp: Bool) -> Bool {
+        return tunnelUp && saved.mode == "ssh" && saved == fields
+    }
+
+    func testExactMatchVouches() {
+        XCTAssertTrue(liveTunnelVouches(saved: Settings(), fields: Settings(), tunnelUp: true))
+    }
+
+    func testNoTunnelNeverVouches() {
+        XCTAssertFalse(liveTunnelVouches(saved: Settings(), fields: Settings(), tunnelUp: false))
+    }
+
+    func testRemotePortMismatchDoesNotVouch() {
+        // The reported bug: remote port edited to 8788 (nothing listening
+        // there) must NOT be verified via the live tunnel's remote 8787.
+        var fields = Settings()
+        fields.remotePort = "8788"
+        XCTAssertFalse(liveTunnelVouches(saved: Settings(), fields: fields, tunnelUp: true))
+    }
+
+    func testAnySingleFieldMismatchDoesNotVouch() {
+        var host = Settings(); host.host = "other.example.com"
+        var user = Settings(); user.user = "someone"
+        var local = Settings(); local.localPort = "9000"
+        for fields in [host, user, local] {
+            XCTAssertFalse(liveTunnelVouches(saved: Settings(), fields: fields, tunnelUp: true))
+        }
+    }
+}
+
+/// Tests for the plaintext-HTTP acknowledgment rule.
+/// Mirrors the guard in `PreferencesWindowController.save()` — plain http to
+/// a non-loopback host requires a one-time per-host acknowledgment that
+/// credentials and session data will cross the network unencrypted.
+final class PlaintextWarningRuleTests: XCTestCase {
+
+    // Mirrors PreferencesWindowController.isLoopbackHost + the save() guard
+    func needsWarning(scheme: String, host: String, acknowledged: [String]) -> Bool {
+        let loopback = host == "localhost" || host == "127.0.0.1" || host == "::1"
+        return scheme == "http" && !loopback && !acknowledged.contains(host)
+    }
+
+    func testRemotePlainHTTPWarns() {
+        XCTAssertTrue(needsWarning(scheme: "http", host: "hermes.example.ts.net", acknowledged: []))
+        XCTAssertTrue(needsWarning(scheme: "http", host: "192.168.1.20", acknowledged: []))
+    }
+
+    func testLoopbackNeverWarns() {
+        // Nothing leaves the machine — also keeps the SSH tunnel entrance
+        // (127.0.0.1) and the default localhost setup prompt-free.
+        XCTAssertFalse(needsWarning(scheme: "http", host: "localhost", acknowledged: []))
+        XCTAssertFalse(needsWarning(scheme: "http", host: "127.0.0.1", acknowledged: []))
+        XCTAssertFalse(needsWarning(scheme: "http", host: "::1", acknowledged: []))
+    }
+
+    func testHTTPSNeverWarns() {
+        XCTAssertFalse(needsWarning(scheme: "https", host: "hermes.example.ts.net", acknowledged: []))
+    }
+
+    func testAcknowledgedHostDoesNotWarnAgain() {
+        XCTAssertFalse(needsWarning(
+            scheme: "http", host: "hermes.example.ts.net",
+            acknowledged: ["hermes.example.ts.net"]))
+    }
+}
+
 /// Tests for the dark-biased appearance threshold (issue #70).
 /// Mirrors `AppDelegate.appearanceForLuminance(_:)` — the rule that decides
 /// whether a sampled page background is "light enough" to flip the chrome


### PR DESCRIPTION
Connection fixes:
- SSH mode loaded the configured Target URL directly, bypassing the ssh -L forward entirely (netstat showed a direct remote connection while the tunnel sat unused). AppDelegate.effectiveTargetURL() now resolves what browser windows load: in SSH mode always the tunnel entrance http://127.0.0.1:<local port>, in direct mode the Target URL. Applied to launch/reconnect, Cmd+N/Cmd+T, and Open in Browser.
- Direct mode rejected every non-localhost URL: the URLSession-based preflight, Test Connection, and health ping are subject to ATS (NSAllowsArbitraryLoads=false), which rejects plain-http to non-loopback hosts with -1022 before the (ATS-exempt) WKWebView gets a chance. All three now use ReachabilityProbe, a hand-rolled HTTP GET of hermes' /health over Network.framework (TLS for https), which ATS does not apply to.

Connection verification:
- The probe is tri-state — healthy (2xx + "status":"ok" body), reachable-but-unverified (port answers; e.g. reverse proxy up, hermes down), unreachable — surfaced in Test Connection and the direct-mode title dot (● / ◐ / ○). Dock badge only on unreachable.
- Test Connection in SSH mode runs a real non-interactive login (ssh -o BatchMode=yes user@host exit), distinguishing "no SSH" from "auth refused" (→ ssh-copy-id hint). After auth it verifies hermes end-to-end: through the live tunnel when every forward-shaping setting matches what it was built from, otherwise through a temporary ssh -N -L created from the field settings and torn down after the probe. Local port collisions report "port busy" (bind pre-check, so a stray listener can't masquerade as the tunnel); when our own live tunnel holds the port, the test detours through an ephemeral port. Editing any field or switching modes clears a stale test verdict.

Preferences UX:
- Mode segment is now "Tunnel: None | SSH" (persisted values unchanged); SSH sections dim/disable instead of hiding, so the fixed-frame layout keeps its shape. In SSH mode the Target URL row becomes a read-only derived tunnel-entrance label.
- Saving a plain-http Target URL to a non-loopback host asks a one-time per-host acknowledgment that credentials and session data cross the network unencrypted; loopback is exempt.

Hardening:
- SSH username/host fields reject option smuggling (leading "-", whitespace) at Save, Test Connection, and inside testAuth / testForward; BatchMode prevents invisible password prompts and a watchdog bounds stalled handshakes.
- The health probe builds its request from the percent-encoded URL path so encoded CR/LF cannot reshape the hand-rolled HTTP request.

60 unit tests (mirror-style, matching the existing suite) cover the effective-URL rule, probe endpoint/path derivation, health-response classification, auth-attempt classification, live-tunnel match rule, ssh identifier validation, and the plaintext-warning rule.