### PR TITLE
fix: swallow Escape when find bar is closed

### DIFF
--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -1508,14 +1508,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         window?.makeFirstResponder(webView)
     }
 
-    // cancelOperation is sent by AppKit when the user presses Escape while
-    // the find field is first responder. Closing the bar here satisfies the
-    // CHANGELOG claim that Escape dismisses the bar.
+    // cancelOperation is sent by AppKit when the user presses Escape.
+    // Only act when the find bar is open — swallow it otherwise so Escape
+    // doesn't bubble up to NSWindow.performClose and hide the window.
     override func cancelOperation(_ sender: Any?) {
         if findBarVisible {
             hideFindBar()
-        } else {
-            super.cancelOperation(sender)
         }
     }
 


### PR DESCRIPTION
## Summary
- Escape key was propagating past the find bar when closed, causing unintended behavior downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)