### PR TITLE
release: v1.7.3 — Escape no longer hides the window (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v1.7.3] — 2026-07-18
+
+### Fixed
+- **Escape no longer hides the window — PR #93** — pressing Escape with the find bar closed could make the entire window vanish (the last-window close path hides via `orderOut` rather than closing, so the whole app seemed to disappear). Root cause: `cancelOperation(_:)` called `super.cancelOperation` on the no-find-bar path, but that NSResponder key-binding method is declared without an implementation — every bare Escape threw an unrecognized-selector exception inside WebKit's command dispatch (`executeSavedCommandBySelector`), caught by AppKit's event-loop guard but leaving dispatch in an undefined state that could bubble into `performClose`. Escape is now swallowed when the find bar is closed; Escape-closes-find-bar behavior is unchanged. Contributed by @roryford.
+
 ## [v1.7.2] — 2026-07-11
 
 ### Fixed

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -1508,14 +1508,12 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         window?.makeFirstResponder(webView)
     }
 
-    // cancelOperation is sent by AppKit when the user presses Escape while
-    // the find field is first responder. Closing the bar here satisfies the
-    // CHANGELOG claim that Escape dismisses the bar.
+    // cancelOperation is sent by AppKit when the user presses Escape.
+    // Only act when the find bar is open — swallow it otherwise so Escape
+    // doesn't bubble up to NSWindow.performClose and hide the window.
     override func cancelOperation(_ sender: Any?) {
         if findBarVisible {
             hideFindBar()
-        } else {
-            super.cancelOperation(sender)
         }
     }
 


### PR DESCRIPTION
## v1.7.3 — staged release

Single-fix release: PR #93 (@roryford), the Escape-hides-window fix, merged with a CHANGELOG entry. Full analysis in the PR #93 approval review.

### Contents
- **#93 (@roryford)** — `cancelOperation(_:)` no longer calls `super.cancelOperation` when the find bar is closed. The super call hit a declared-but-unimplemented NSResponder method, throwing an unrecognized-selector exception inside WebKit's command dispatch on every bare Escape press — surfacing as the window vanishing (last-window close path hides via `orderOut`). Escape-closes-find-bar is unchanged.
- CHANGELOG entry for v1.7.3.

### Verification (local, macOS)
- `swift build -c release` — clean at PR tip and on this merged branch
- `swift test` — 62/62 passed on this branch
- `bash build.sh` — packaged, ad-hoc signed; ATS/Sparkle Info.plist keys verified; smoke-launched against a live server
- Standalone AppKit+WKWebView harness reproduced the old path's unrecognized-selector throw inside `executeSavedCommandBySelector` and verified the new path runs clean (cancelOperation fires, window stays visible)
- PR #93 approved at tip `786706c`

### Merge notes
**Merge with a merge commit (not squash)** — the branch carries #93's head commit, so a regular merge marks the contributor PR as merged.

After merge: tag `v1.7.3` → CI builds the DMG, creates the GitHub Release, and commits the appcast entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
