### PR TITLE
Fix long-conversation freeze on macOS (WKWebView)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Long conversations no longer enter WebKit's virtual-measurement retry loop** — the macOS client now installs a document-start compatibility guard for the upstream transcript-virtualization bug tracked by hermes-webui PR #6668. When the loaded scheduler still contains the faulty per-window retry reset, virtualization uses WebUI's supported non-virtualized fallback inside WKWebView only. Browser and iOS clients remain unchanged, and virtualization automatically resumes in the Mac client once the server supplies the corrected scheduler.
+
 ## [v1.7.3] — 2026-07-18
 
 ### Fixed

--- a/Sources/HermesAgent/BrowserWindowController.swift
+++ b/Sources/HermesAgent/BrowserWindowController.swift
@@ -77,6 +77,50 @@ private class TitleBarDragView: NSView {
 
 class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegate, WKNavigationDelegate, WKScriptMessageHandler {
 
+    /// WKWebView-only compatibility guard for the upstream transcript-virtualization
+    /// retry loop (hermes-webui PR #6668). The affected WebUI scheduler resets its
+    /// retry budget whenever WebKit's measured virtual window changes, so alternating
+    /// measurements can schedule layout work forever on long conversations.
+    ///
+    /// WebUI already provides `_virtualizeTranscript === false` as its supported
+    /// non-virtualized path. This document-start accessor remembers the server's
+    /// requested setting but reports it as disabled while the loaded scheduler still
+    /// contains the known bad reset. Once the upstream fix is deployed, the reset is
+    /// absent and the server setting takes effect automatically. Remove this shim once
+    /// supported WebUI versions universally include that fix.
+    static let longConversationWebKitCompatibilityScript = """
+        (function() {
+            const marker = '__hermesMacLongConversationCompatibilityPatch';
+            if (window[marker]) return;
+
+            const functionToString = Function.prototype.toString;
+            let requestedValue = window._virtualizeTranscript === true;
+
+            Object.defineProperty(window, marker, {
+                value: true,
+                configurable: false,
+                enumerable: false
+            });
+            Object.defineProperty(window, '_virtualizeTranscript', {
+                configurable: true,
+                enumerable: true,
+                get: function() {
+                    if (!requestedValue) return false;
+                    const scheduler = window._scheduleMessageVirtualMeasurementRefresh;
+                    if (typeof scheduler !== 'function') return false;
+                    const source = functionToString.call(scheduler);
+                    const compactSource = Array.from(source)
+                        .filter(function(character) { return character.charCodeAt(0) > 32; })
+                        .join('');
+                    return !compactSource.includes('_messageVirtualMeasurementRetryCount=0');
+                },
+                set: function(value) {
+                    requestedValue = value === true;
+                }
+            });
+        })();
+        """
+
     private var webView: HermesWebView!
     private var statusBar: NSView!
 
@@ -265,6 +309,17 @@ class BrowserWindowController: NSWindowController, NSWindowDelegate, WKUIDelegat
         prefs.setValue(true, forKey: "javaScriptCanAccessClipboard")
         prefs.setValue(true, forKey: "DOMPasteAllowed")
         config.preferences = prefs
+
+        // Install before any page content loads so the WebUI settings bootstrap
+        // cannot enable the affected virtualizer before this client-side guard.
+        // Main-frame-only keeps the override out of embedded documents.
+        let longConversationCompatibilityScript = WKUserScript(
+            source: Self.longConversationWebKitCompatibilityScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        config.userContentController.addUserScript(longConversationCompatibilityScript)
+
         let pasteScript = WKUserScript(
             source:
                 "document.addEventListener('paste', function(e) { e.stopImmediatePropagation(); }, true);",

--- a/Tests/HermesAgentTests/LongConversationCompatibilityTests.swift
+++ b/Tests/HermesAgentTests/LongConversationCompatibilityTests.swift
@@ -1,0 +1,108 @@
+import JavaScriptCore
+import XCTest
+
+/// Regression coverage for the WKWebView-only transcript virtualization guard.
+///
+/// The production script lives in BrowserWindowController.swift. These tests extract
+/// and execute that exact script so changes to the injected JavaScript are exercised,
+/// rather than testing a hand-copied Swift model of its behavior.
+final class LongConversationCompatibilityTests: XCTestCase {
+
+    private func productionScript() throws -> String {
+        let repositoryRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // HermesAgentTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // repository root
+        let controllerURL = repositoryRoot
+            .appendingPathComponent("Sources/HermesAgent/BrowserWindowController.swift")
+        let source = try String(contentsOf: controllerURL, encoding: .utf8)
+        let opening = "static let longConversationWebKitCompatibilityScript = \"\"\"\n"
+        let closing = "\n        \"\"\""
+
+        guard let openingRange = source.range(of: opening),
+              let closingRange = source.range(
+                of: closing,
+                range: openingRange.upperBound..<source.endIndex
+              )
+        else {
+            throw NSError(
+                domain: "LongConversationCompatibilityTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Compatibility script not found"]
+            )
+        }
+        return String(source[openingRange.upperBound..<closingRange.lowerBound])
+    }
+
+    private func context(
+        schedulerBody: String?,
+        requestedValue: Bool,
+        installTwice: Bool = false
+    ) throws -> JSContext {
+        let context = try XCTUnwrap(JSContext())
+        var exception: JSValue?
+        context.exceptionHandler = { _, value in exception = value }
+        context.evaluateScript("var window = this;")
+
+        let script = try productionScript()
+        context.evaluateScript(script)
+        if let schedulerBody {
+            context.evaluateScript(
+                "window._scheduleMessageVirtualMeasurementRefresh = function() { \(schedulerBody) };"
+            )
+        }
+        context.evaluateScript("window._virtualizeTranscript = \(requestedValue);")
+        if installTwice {
+            context.evaluateScript(script)
+        }
+
+        XCTAssertNil(exception?.toString(), "Injected script raised a JavaScript exception")
+        return context
+    }
+
+    func testKnownBuggySchedulerDisablesVirtualization() throws {
+        let context = try context(
+            schedulerBody: "_messageVirtualMeasurementRetryCount = 0;",
+            requestedValue: true
+        )
+
+        XCTAssertFalse(context.evaluateScript("window._virtualizeTranscript").toBool())
+    }
+
+    func testFixedSchedulerPreservesServerSetting() throws {
+        let context = try context(
+            schedulerBody: "_messageVirtualMeasurementCycleKey=cycleKey;",
+            requestedValue: true
+        )
+
+        XCTAssertTrue(context.evaluateScript("window._virtualizeTranscript").toBool())
+    }
+
+    func testMissingSchedulerFailsClosed() throws {
+        let context = try context(schedulerBody: nil, requestedValue: true)
+
+        XCTAssertFalse(context.evaluateScript("window._virtualizeTranscript").toBool())
+    }
+
+    func testDisabledServerSettingRemainsDisabled() throws {
+        let context = try context(
+            schedulerBody: "_messageVirtualMeasurementCycleKey=cycleKey;",
+            requestedValue: false
+        )
+
+        XCTAssertFalse(context.evaluateScript("window._virtualizeTranscript").toBool())
+    }
+
+    func testRepeatedInstallationIsIdempotent() throws {
+        let context = try context(
+            schedulerBody: "_messageVirtualMeasurementCycleKey=cycleKey;",
+            requestedValue: true,
+            installTwice: true
+        )
+
+        XCTAssertTrue(context.evaluateScript("window._virtualizeTranscript").toBool())
+        XCTAssertTrue(
+            context.evaluateScript("window.__hermesMacLongConversationCompatibilityPatch").toBool()
+        )
+    }
+}

--- a/docs/LONG-CONVERSATION-WKWEBVIEW-COMPATIBILITY.md
+++ b/docs/LONG-CONVERSATION-WKWEBVIEW-COMPATIBILITY.md
@@ -1,0 +1,26 @@
+# WKWebView long-conversation freeze
+
+## Observed freeze
+
+Very long conversations could leave the native macOS app unresponsive while the
+same server remained usable in browser and iOS clients.
+
+## Root cause
+
+The WebUI transcript virtualizer uses a scheduler for WebKit measurement work.
+When WebKit alternated between measurement windows, the scheduler reset its
+retry count and could keep scheduling `requestAnimationFrame` layout work.
+The resulting loop made the WKWebView appear frozen.
+
+## Mitigation and scope
+
+`BrowserWindowController` injects a main-frame-only `WKUserScript` at document
+start. It preserves the server's virtualization setting but temporarily uses
+the supported non-virtualized path while the affected scheduler reset is
+present. The script only affects the macOS wrapper because it runs in that
+wrapper's WKWebView; browser and iOS clients are unchanged.
+
+## Removal
+
+Remove the compatibility script and its tests once the upstream scheduler fix
+is included in every supported WebUI version.


### PR DESCRIPTION
Fixes the macOS app becoming permanently unresponsive when opening long conversations.

The issue is caused by the WebUI transcript virtualization scheduler repeatedly resetting its retry budget under WKWebView.

This adds a macOS-only compatibility guard that disables virtualization only when the affected scheduler behavior is detected. The server and WebUI deployment are unchanged.

Verified with focused regression tests and the full XCTest suite.